### PR TITLE
fix: update Node.js versions in CI workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        # Temporarily pinned due to Node.js 24.6.0 Jest ES modules issue
-        # @@ Switch back to “current” when possible
-        node: ['lts/*', '24.5.0']
+        node: ['lts/*', 'current']
     name: "CI: Node ${{ matrix.node }} (${{ matrix.platform }})"
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Restored the usage of the “current” Node.js version in CI, replacing the temporary pin to version 24.5.0. This resolves the earlier Jest ES modules issue affecting Node.js 24.6.0.

(This commit message was AI-generated.)