### PR TITLE
Trim dependencies (Alpine.js, chalk)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,8 @@
-# To get started with Dependabot version updates, you’ll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "monthly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to this project are documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2025-09-20
+
+### Changed
+
+- Replaced Alpine.js npm dependency with CDN for demo page to reduce dev dependencies
+
 ## [2.1.3] - 2025-09-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Replaced Alpine.js npm dependency with CDN for demo page to reduce dev dependencies
-- Disabled “Remove tag whitespace” option by default in demo to prevent invalid HTML output
+- Improved demo safety by not marking unsafe options by default (to prevent invalid HTML output)
 
 ## [2.1.3] - 2025-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Replaced Alpine.js npm dependency with CDN for demo page to reduce dev dependencies
+- Disabled “Remove tag whitespace” option by default in demo to prevent invalid HTML output
 
 ## [2.1.3] - 2025-09-14
 

--- a/README.md
+++ b/README.md
@@ -131,25 +131,25 @@ How does HTML Minifier Next compare to other solutions, like [minimize](https://
 
 | Site | Original size (KB) | HTML Minifier Next | minimize | html­compressor.com | htmlnano | minify-html |
 | --- | --- | --- | --- | --- | --- | --- |
-| [A List Apart](https://alistapart.com/) | 64 | **54** | 59 | 57 | 55 | 56 |
-| [Amazon](https://www.amazon.com/) | 710 | **637** | 697 | n/a | n/a | n/a |
-| [Apple](https://www.apple.com/) | 211 | **170** | 197 | 194 | 188 | 194 |
-| [BBC](https://www.bbc.co.uk/) | 676 | **622** | 671 | n/a | 635 | 636 |
-| [CSS-Tricks](https://css-tricks.com/) | 165 | **122** | 151 | 147 | 129 | 146 |
+| [A List Apart](https://alistapart.com/) | 63 | **54** | 58 | 57 | 55 | 56 |
+| [Amazon](https://www.amazon.com/) | 5 | **3** | **3** | **3** | **3** | n/a |
+| [Apple](https://www.apple.com/) | 212 | **171** | 198 | 195 | 189 | 194 |
+| [BBC](https://www.bbc.co.uk/) | 742 | **683** | 736 | n/a | 698 | 699 |
+| [CSS-Tricks](https://css-tricks.com/) | 11 | **6** | 11 | 10 | 7 | n/a |
 | [ECMAScript](https://tc39.es/ecma262/) | 7205 | **6315** | 6585 | n/a | 6532 | 6538 |
-| [EFF](https://www.eff.org/) | 59 | **50** | 53 | 53 | 53 | 51 |
-| [FAZ](https://www.faz.net/aktuell/) | 1788 | 1672 | 1705 | n/a | **1579** | n/a |
+| [EFF](https://www.eff.org/) | 60 | **51** | 55 | 55 | 54 | 53 |
+| [FAZ](https://www.faz.net/aktuell/) | 1847 | 1728 | 1764 | n/a | **1630** | n/a |
 | [Frontend Dogma](https://frontenddogma.com/) | 117 | **112** | 126 | 117 | 124 | 117 |
 | [Google](https://www.google.com/) | 18 | **16** | 17 | 17 | **16** | n/a |
-| [Ground News](https://ground.news/) | 1804 | **1560** | 1791 | n/a | 1657 | n/a |
-| [HTML](https://html.spec.whatwg.org/multipage/) | 149 | **146** | 154 | 148 | 153 | 148 |
-| [Leanpub](https://leanpub.com/) | 1361 | **1147** | 1355 | n/a | 1154 | n/a |
+| [Ground News](https://ground.news/) | 1509 | **1287** | 1495 | n/a | 1386 | n/a |
+| [HTML](https://html.spec.whatwg.org/multipage/) | 149 | **146** | 155 | 148 | 153 | 148 |
+| [Leanpub](https://leanpub.com/) | 1361 | **1143** | 1355 | n/a | 1150 | n/a |
 | [Mastodon](https://mastodon.social/explore) | 35 | **25** | 33 | 33 | 30 | 33 |
-| [MDN](https://developer.mozilla.org/en-US/) | 153 | 94 | 99 | 99 | **80** | n/a |
+| [MDN](https://developer.mozilla.org/en-US/) | 104 | **62** | 67 | 68 | 64 | n/a |
 | [Middle East Eye](https://www.middleeasteye.net/) | 221 | **194** | 201 | 202 | 201 | 199 |
-| [SitePoint](https://www.sitepoint.com/) | 480 | **350** | 477 | n/a | 419 | 460 |
-| [United Nations](https://www.un.org/en/) | 151 | **114** | 130 | 123 | 121 | 125 |
-| [W3C](https://www.w3.org/) | 48 | **34** | 39 | 37 | 37 | 37 |
+| [SitePoint](https://www.sitepoint.com/) | 469 | **338** | 466 | n/a | 408 | 449 |
+| [United Nations](https://www.un.org/en/) | 153 | **116** | 132 | 125 | 123 | 127 |
+| [W3C](https://www.w3.org/) | 49 | **35** | 40 | 38 | 37 | 38 |
 
 ## Options quick reference
 

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -8,8 +8,8 @@ import { fork } from 'child_process';
 import { fileURLToPath } from 'url';
 import { pipeline } from 'stream/promises';
 import { createReadStream, createWriteStream } from 'fs';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk';
 import lzma from 'lzma';
 import Minimize from 'minimize';
 import Progress from 'progress';
@@ -48,17 +48,17 @@ function toKb(size, precision) {
 }
 
 function redSize(size) {
-  return chalk.red.bold(size) + chalk.white(' (' + toKb(size, 2) + ' KB)');
+  return styleText(['red', 'bold'], String(size)) + styleText(['white'], ' (' + toKb(size, 2) + ' KB)');
 }
 
 function greenSize(size) {
-  return chalk.green.bold(size) + chalk.white(' (' + toKb(size, 2) + ' KB)');
+  return styleText(['green', 'bold'], String(size)) + styleText(['white'], ' (' + toKb(size, 2) + ' KB)');
 }
 
 function blueSavings(oldSize, newSize) {
   // Handle invalid inputs
   if (!oldSize || oldSize <= 0 || typeof oldSize !== 'number') {
-    return chalk.white('N/A');
+    return styleText(['white'], 'N/A');
   }
   if (typeof newSize !== 'number' || newSize < 0) {
     newSize = 0; // Treat invalid newSize as 0
@@ -66,11 +66,11 @@ function blueSavings(oldSize, newSize) {
 
   const savingsPercent = (1 - newSize / oldSize) * 100;
   const savings = oldSize - newSize;
-  return chalk.cyan.bold(savingsPercent.toFixed(2)) + chalk.white('% (' + toKb(savings, 2) + ' KB)');
+  return styleText(['cyan', 'bold'], savingsPercent.toFixed(2)) + styleText(['white'], '% (' + toKb(savings, 2) + ' KB)');
 }
 
 function blueTime(time) {
-  return chalk.cyan.bold(time) + chalk.white(' ms');
+  return styleText(['cyan', 'bold'], String(time)) + styleText(['white'], ' ms');
 }
 
 async function readBuffer(filePath) {
@@ -658,7 +658,7 @@ if (benchmarkErrors.length > 0) {
   console.log();
   console.log('Benchmark warnings and errors:');
   benchmarkErrors.forEach(error => {
-    console.log(chalk.red(`• ${error}`));
+    console.log(styleText(['red'], `• ${error}`));
   });
   console.log();
 }

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -9,13 +9,13 @@ import { fileURLToPath } from 'url';
 import { pipeline } from 'stream/promises';
 import { createReadStream, createWriteStream } from 'fs';
 import { styleText } from 'node:util';
-
 import lzma from 'lzma';
 import Minimize from 'minimize';
 import Progress from 'progress';
 import Table from 'cli-table3';
 import htmlnano from 'htmlnano';
 import minifyHTMLPkg from '@minify-html/node';
+
 const { minify: minifyHTML } = minifyHTMLPkg;
 
 const __filename = fileURLToPath(import.meta.url);

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -7,7 +7,6 @@
       "name": "html-minifier-next-benchmarks",
       "dependencies": {
         "@minify-html/node": "^0.16.4",
-        "chalk": "^4.1.2",
         "cli-table3": "^0.6.5",
         "cssnano": "^7.0.9",
         "htmlnano": "^2.1.2",
@@ -144,21 +143,6 @@
       "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
       "license": "MIT"
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/argh": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
@@ -269,22 +253,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/cli-color": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
@@ -331,18 +299,6 @@
       "dependencies": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
@@ -910,15 +866,6 @@
       "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/htmlnano": {
@@ -2018,18 +1965,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/svgo": {

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -2,7 +2,6 @@
   "type": "module",
   "dependencies": {
     "@minify-html/node": "^0.16.4",
-    "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "cssnano": "^7.0.9",
     "htmlnano": "^2.1.2",

--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,6 @@ import { Command } from 'commander';
 import { minify } from './src/htmlminifier.js';
 
 const require = createRequire(import.meta.url);
-
 const pkg = require('./package.json');
 
 const program = new Command();

--- a/demo/index.html
+++ b/demo/index.html
@@ -73,6 +73,7 @@
         </p>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js" defer></script>
     <script src="./main.js" type="module"></script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -73,7 +73,7 @@
         </p>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js" defer></script>
     <script src="./main.js" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js" defer></script>
   </body>
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -187,7 +187,7 @@ const defaultOptions = [
     type: 'checkbox',
     label: 'Remove tag whitespace',
     helpText: `Remove space between attributes whenever possible; <em>note that this will result in invalid HTML</em>`,
-    checked: true,
+    checked: false,
     unsafe: true
   },
   {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,4 +1,3 @@
-import Alpine from 'alpinejs';
 import HTMLMinifier from '../dist/htmlminifier.esm.bundle.js';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -253,7 +252,7 @@ const getOptions = (options) => {
   return minifierOptions;
 };
 
-Alpine.data('minifier', () => ({
+window.Alpine.data('minifier', () => ({
   options: sillyClone(defaultOptions),
   input: '',
   output: '',
@@ -304,6 +303,6 @@ Alpine.data('minifier', () => ({
   }
 }));
 
-Alpine.start();
+window.Alpine.start();
 
 document.getElementById('minifier-version').innerText = `(v${pkg.version})`;

--- a/demo/main.js
+++ b/demo/main.js
@@ -252,57 +252,58 @@ const getOptions = (options) => {
   return minifierOptions;
 };
 
-window.Alpine.data('minifier', () => ({
-  options: sillyClone(defaultOptions),
-  input: '',
-  output: '',
-  stats: {
-    result: '',
-    text: ''
-  },
-
-  async minify() {
-    this.stats = {
+// Register Alpine data before Alpine starts
+document.addEventListener('alpine:init', () => {
+  window.Alpine.data('minifier', () => ({
+    options: sillyClone(defaultOptions),
+    input: '',
+    output: '',
+    stats: {
       result: '',
       text: ''
-    };
+    },
 
-    const options = getOptions(this.options);
-
-    try {
-      const data = await HTMLMinifier.minify(this.input, options);
-
-      const diff = this.input.length - data.length;
-      const savings = this.input.length ? (100 * diff / this.input.length).toFixed(2) : 0;
-
-      this.output = data;
-      this.stats.result = 'success';
-      this.stats.text = `Original Size: ${this.input.length}, minified size: ${data.length}, savings: ${diff} (${savings}%)`;
-    } catch (err) {
-      this.stats.result = 'failure';
-      this.stats.text = err + '';
-      console.error(err);
-    }
-  },
-
-  selectAllOptions(yes = true) {
-    this.options = this.options.map((option) => {
-      if (option.type !== 'checkbox') {
-        return option;
-      }
-
-      return {
-        ...option,
-        checked: Boolean(yes)
+    async minify() {
+      this.stats = {
+        result: '',
+        text: ''
       };
-    });
-  },
 
-  resetOptions() {
-    this.options = sillyClone(defaultOptions);
-  }
-}));
+      const options = getOptions(this.options);
 
-window.Alpine.start();
+      try {
+        const data = await HTMLMinifier.minify(this.input, options);
+
+        const diff = this.input.length - data.length;
+        const savings = this.input.length ? (100 * diff / this.input.length).toFixed(2) : 0;
+
+        this.output = data;
+        this.stats.result = 'success';
+        this.stats.text = `Original Size: ${this.input.length}, minified size: ${data.length}, savings: ${diff} (${savings}%)`;
+      } catch (err) {
+        this.stats.result = 'failure';
+        this.stats.text = err + '';
+        console.error(err);
+      }
+    },
+
+    selectAllOptions(yes = true) {
+      this.options = this.options.map((option) => {
+        if (option.type !== 'checkbox') {
+          return option;
+        }
+
+        return {
+          ...option,
+          checked: Boolean(yes)
+        };
+      });
+    },
+
+    resetOptions() {
+      this.options = sillyClone(defaultOptions);
+    }
+  }));
+});
 
 document.getElementById('minifier-version').innerText = `(v${pkg.version})`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",
@@ -27,7 +27,6 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
-        "alpinejs": "^3.15.0",
         "eslint": "^9.35.0",
         "jest": "^30.1.3",
         "rollup": "^4.50.0",
@@ -2980,21 +2979,6 @@
         "win32"
       ]
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-      "dev": true,
-      "dependencies": {
-        "@vue/shared": "3.1.5"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3029,15 +3013,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/alpinejs": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
-      "integrity": "sha512-lpokA5okCF1BKh10LG8YjqhfpxyHBk4gE7boIgVHltJzYoM7O9nK3M7VlntLEJGsVmu7U/RzUWajmHREGT38Eg==",
-      "dev": true,
-      "dependencies": {
-        "@vue/reactivity": "~3.1.1"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
-    "alpinejs": "^3.15.0",
     "eslint": "^9.35.0",
     "jest": "^30.1.3",
     "rollup": "^4.50.0",
@@ -86,5 +85,5 @@
     "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch"
   },
   "type": "module",
-  "version": "2.1.3"
+  "version": "2.1.4"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -2,7 +2,6 @@ import CleanCSS from 'clean-css';
 import { decodeHTMLStrict, decodeHTML } from 'entities';
 import RelateURL from 'relateurl';
 import { minify as terser } from 'terser';
-
 import { HTMLParser, endTag } from './htmlparser.js';
 import TokenChain from './tokenchain.js';
 import { replaceAsync } from './utils.js';

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
-
 import { describe, test, expect, beforeEach } from '@jest/globals';
 import { minify } from '../src/htmlminifier.js';
 


### PR DESCRIPTION
Resolves #76.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added changelog entry for 2.1.4 and refreshed README benchmark results.
- Refactor
  - Demo now loads Alpine.js from a CDN and initializes more robustly.
  - Demo safer by disabling the "remove tag whitespace" option by default to avoid invalid HTML.
- Chores
  - Removed unused dev dependencies and adjusted benchmark output styling.
  - Bumped package version to 2.1.4.
- Style
  - Minor formatting cleanups with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->