### PR TITLE
Improve tests for optional tags handling, revise ruby markup, lightly edit docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-As of version 2.0.0, all notable changes to this project are documented in this file, which is (mostly) AI-generated and (always) human-edited. Dependency updates may or may not be called out specifically.
+As of version 2.0.0, all notable changes to HTML Minifier Next are documented in this file, which is (mostly) AI-generated and (always) human-edited. Dependency updates may or may not be called out specifically.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -8,19 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added support for HTML Ruby Markup Extensions ([June 2024 Working Draft](https://www.w3.org/TR/2024/WD-html-ruby-extensions-20240627/)) to handle extended ruby annotation markup
+- Added support for HTML Ruby Markup Extensions ([June 2024 draft](https://www.w3.org/TR/2024/WD-html-ruby-extensions-20240627/)) to handle extended ruby annotation markup
 - Added `dialog` and `search` elements to `<p>` end tag omission rules per current HTML specification
 
-### Changed
+### Changed/fixed
 
 - Updated ruby element tag omission logic to correctly handle all conforming elements: `<ruby>`, `<rp>`, `<rt>`, `<rb>`, `<rtc>`
 - Improved optional tag removal for ruby elements when `removeOptionalTags` and `collapseWhitespace` options are enabled
 - Enhanced whitespace handling to preserve `optionalEndTag` tracking through collapsible whitespace (unless `conservativeCollapse` is enabled)
-
-### Fixed
-
-- Fixed `<rtc>` end tag omission to correctly preserve `</rtc>` before `<rt>` or `<rp>` elements (per spec: rtc end tag can only be omitted before `<rb>` or `<rtc>`)
-- Fixed ruby element optional tag removal to work correctly with whitespace between tags
 
 ## [2.1.5] - 2025-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ As of version 2.0.0, all notable changes to this project are documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2025-10-07
+
+### Added
+
+- Added support for HTML Ruby Markup Extensions ([June 2024 Working Draft](https://www.w3.org/TR/2024/WD-html-ruby-extensions-20240627/)) to handle extended ruby annotation markup
+- Added `dialog` and `search` elements to `<p>` end tag omission rules per current HTML specification
+
+### Changed
+
+- Updated ruby element tag omission logic to correctly handle all conforming elements: `<ruby>`, `<rp>`, `<rt>`, `<rb>`, `<rtc>`
+- Improved optional tag removal for ruby elements when `removeOptionalTags` and `collapseWhitespace` options are enabled
+- Enhanced whitespace handling to preserve `optionalEndTag` tracking through collapsible whitespace (unless `conservativeCollapse` is enabled)
+
+### Fixed
+
+- Fixed `<rtc>` end tag omission to correctly preserve `</rtc>` before `<rt>` or `<rp>` elements (per spec: rtc end tag can only be omitted before `<rb>` or `<rtc>`)
+- Fixed ruby element optional tag removal to work correctly with whitespace between tags
+
 ## [2.1.5] - 2025-09-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -85,5 +85,5 @@
     "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch"
   },
   "type": "module",
-  "version": "2.1.5"
+  "version": "2.1.6"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -416,7 +416,7 @@ async function processScript(text, options, currentAttrs) {
 
 // Tag omission rules from https://html.spec.whatwg.org/multipage/syntax.html#optional-tags with the following extensions:
 // - retain <body> if followed by <noscript>
-// - <rb>, <rt>, <rtc>, <rp> follow W3C Ruby Markup Extensions draft (https://www.w3.org/TR/html-ruby-extensions/)
+// - <rb>, <rt>, <rtc>, <rp> follow HTML Ruby Markup Extensions draft (https://www.w3.org/TR/html-ruby-extensions/)
 // - retain all tags which are adjacent to non-standard HTML tags
 const optionalStartTags = new Set(['html', 'head', 'body', 'colgroup', 'tbody']);
 const optionalEndTags = new Set(['html', 'head', 'body', 'li', 'dt', 'dd', 'p', 'rb', 'rt', 'rtc', 'rp', 'optgroup', 'option', 'colgroup', 'caption', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th']);

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1093,7 +1093,7 @@ async function minifyHTML(value, options, partialMarkup) {
       let optional = options.removeOptionalTags;
       if (optional) {
         const htmlTag = htmlTags.has(tag);
-        // <html> may be omitted if first thing inside is not comment
+        // <html> may be omitted if first thing inside is not a comment
         // <head> may be omitted if first thing inside is an element
         // <body> may be omitted if first thing inside is not space, comment, <meta>, <link>, <script>, <style> or <template>
         // <colgroup> may be omitted if first thing inside is <col>
@@ -1112,7 +1112,7 @@ async function minifyHTML(value, options, partialMarkup) {
         optionalEndTag = '';
       }
 
-      // Set whitespace flags for nested tags (eg. <code> within a <pre>)
+      // Set whitespace flags for nested tags (e.g., <code> within a <pre>)
       if (options.collapseWhitespace) {
         if (!stackNoTrimWhitespace.length) {
           squashTrailingWhitespace(tag);
@@ -1280,7 +1280,7 @@ async function minifyHTML(value, options, partialMarkup) {
         text = await options.minifyCSS(text);
       }
       if (options.removeOptionalTags && text) {
-        // <html> may be omitted if first thing inside is not comment
+        // <html> may be omitted if first thing inside is not a comment
         // <body> may be omitted if first thing inside is not space, comment, <meta>, <link>, <script>, <style> or <template>
         if (optionalStartTag === 'html' || (optionalStartTag === 'body' && !/^\s/.test(text))) {
           removeStartTag();
@@ -1348,7 +1348,7 @@ async function minifyHTML(value, options, partialMarkup) {
   await parser.parse();
 
   if (options.removeOptionalTags) {
-    // <html> may be omitted if first thing inside is not comment
+    // <html> may be omitted if first thing inside is not a comment
     // <head> or <body> may be omitted if empty
     if (topLevelTags.has(optionalStartTag)) {
       removeStartTag();


### PR DESCRIPTION
Resolves #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Support for HTML Ruby Markup Extensions (rb, rt, rtc, rp); dialog and search recognized in optional end‑tag rules.
* Improvements
  - More reliable optional-tag removal when collapsing whitespace; preserves end-tag tracking through collapsible whitespace unless conservative collapse is enabled.
* Bug Fixes
  - Corrected ruby end‑tag omission behavior so closing rtc/rt/rp are handled correctly with surrounding whitespace.
* Documentation
  - Added changelog entry for v2.1.6.
* Tests
  - Added extensive tests for optional tags and extended ruby markup.
* Chores
  - Bumped version to 2.1.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->