### PR TITLE
Remove `conservativeCollapse` from the `comprehensive` preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1] - 2025-11-28
+
+### Changed
+
+- Removed `conservativeCollapse` from `comprehensive` preset
+
 ## [4.5.0] - 2025-11-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
         "@types/relateurl": "^0.2.33",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
     "test:watch": "node --test --watch tests/*.spec.js"
   },
   "type": "module",
-  "version": "4.5.0"
+  "version": "4.5.1"
 }

--- a/src/presets.js
+++ b/src/presets.js
@@ -26,7 +26,6 @@ export const presets = {
     collapseBooleanAttributes: true,
     collapseInlineTagWhitespace: true,
     collapseWhitespace: true,
-    conservativeCollapse: true,
     continueOnParseError: true,
     decodeEntities: true,
     minifyCSS: true,


### PR DESCRIPTION
(Too conservative in this setting.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Removed conservativeCollapse option from comprehensive and conservative presets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->