### PR TITLE
Enable `type=module` optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-04-07
+
+### Added
+
+* `<script type=module>` now automatically enables Terser’s and SWC’s `module: true` option, unlocking ES module–specific optimizations (e.g., unused variable elimination) that are only safe in module scope; classic scripts are unaffected
+
 ## [6.0.0] - 2026-04-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.0.0"
+  "version": "6.1.0"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1331,7 +1331,7 @@ async function minifyHTML(value, options, partialMarkup) {
       const needsProcessScript = specialContentElements.has(currentTag) && (options.processScripts || hasJsonScriptType(currentAttrs));
       const needsMinifyJS = options.minifyJS !== identity && isExecutableScript(currentTag, currentAttrs);
       const isModuleScript = needsMinifyJS && currentAttrs.some(
-        a => a.name.toLowerCase() === 'type' && a.value.trim().toLowerCase() === 'module'
+        a => a.name.toLowerCase() === 'type' && (a.value ?? '').trim().toLowerCase() === 'module'
       );
       const needsMinifyCSS = options.minifyCSS !== identity && isStyleElement(currentTag, currentAttrs);
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1003,11 +1003,11 @@ async function minifyHTML(value, options, partialMarkup) {
 
         if (options.minifyJS) {
           options.minifyJS = (function (fn) {
-            return function (text, type) {
+            return function (text, inline, isModule) {
               return fn(text.replace(uidPattern, function (match, prefix, index) {
                 const chunks = ignoredCustomMarkupChunks[+index];
                 return chunks[1] + uidAttr + index + uidAttr + chunks[2];
-              }), type);
+              }), inline, isModule);
             };
           })(options.minifyJS);
         }
@@ -1330,6 +1330,9 @@ async function minifyHTML(value, options, partialMarkup) {
       const needsDecode = options.decodeEntities && text && !specialContentElements.has(currentTag) && text.indexOf('&') !== -1;
       const needsProcessScript = specialContentElements.has(currentTag) && (options.processScripts || hasJsonScriptType(currentAttrs));
       const needsMinifyJS = options.minifyJS !== identity && isExecutableScript(currentTag, currentAttrs);
+      const isModuleScript = needsMinifyJS && currentAttrs.some(
+        a => a.name.toLowerCase() === 'type' && a.value.trim().toLowerCase() === 'module'
+      );
       const needsMinifyCSS = options.minifyCSS !== identity && isStyleElement(currentTag, currentAttrs);
 
       // Whitespace collapsing phase (sync); captures `prevTag`/`nextTag`/`prevAttrs`/`nextAttrs` from outer scope
@@ -1456,7 +1459,7 @@ async function minifyHTML(value, options, partialMarkup) {
           text = await processScript(text, options, currentAttrs, minifyHTML);
         }
         if (needsMinifyJS) {
-          text = await options.minifyJS(text);
+          text = await options.minifyJS(text, false, isModuleScript);
         }
         if (needsMinifyCSS) {
           text = await options.minifyCSS(text);

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -265,7 +265,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                   ...terserOptions.parse,
                   bare_returns: inline
                 },
-                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for <script type=module>
+                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for `<script type=module>`
               };
               const terser = await getTerser();
               const result = await terser(code, terserCallOptions);
@@ -277,7 +277,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                 compress: true,
                 mangle: true,
                 ...swcOptions,
-                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for <script type=module>
+                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for `<script type=module>`
               });
               return result.code.replace(RE_TRAILING_SEMICOLON, '');
             }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -228,7 +228,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         cont: !!options.continueOnMinifyError
       });
 
-      options.minifyJS = async function (text, inline) {
+      options.minifyJS = async function (text, inline, isModule) {
         const start = text.match(/^\s*<!--.*/);
         const code = start ? text.slice(start[0].length).replace(/\n\s*-->\s*$/, '') : text;
 
@@ -248,7 +248,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
           // For large inputs, use length and content fingerprint to prevent collisions
           jsKey = (code.length > 2048 ? (code.length + '|' + code.slice(0, 50) + code.slice(-50) + '|') : (code + '|'))
-            + (inline ? '1' : '0') + '|' + useEngine + '|' + optsSig;
+            + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
           const cached = jsMinifyCache.get(jsKey);
           if (cached) {
@@ -264,7 +264,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                 parse: {
                   ...terserOptions.parse,
                   bare_returns: inline
-                }
+                },
+                ...(isModule ? { module: true } : {})
               };
               const terser = await getTerser();
               const result = await terser(code, terserCallOptions);
@@ -276,6 +277,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                 compress: true,
                 mangle: true,
                 ...swcOptions, // User options override defaults
+                ...(isModule ? { module: true } : {})
               });
               return result.code.replace(RE_TRAILING_SEMICOLON, '');
             }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -265,7 +265,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                   ...terserOptions.parse,
                   bare_returns: inline
                 },
-                ...(isModule ? { module: true } : {})
+                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for <script type=module>
               };
               const terser = await getTerser();
               const result = await terser(code, terserCallOptions);
@@ -276,8 +276,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
               const result = await swc.minify(code, {
                 compress: true,
                 mangle: true,
-                ...swcOptions, // User options override defaults
-                ...(isModule ? { module: true } : {})
+                ...swcOptions,
+                ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for <script type=module>
               });
               return result.code.replace(RE_TRAILING_SEMICOLON, '');
             }

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -426,6 +426,40 @@ describe('CSS and JS', () => {
     assert.strictEqual(result2, result3, 'Case variations should produce same result');
   });
 
+  test('JS: `type=module` enables module-specific optimizations', async () => {
+    let input, output;
+
+    // Module-specific optimization: unused variable elimination (only safe in module scope)
+    input = '<script type=module>let foo=1;console.log(foo)</script>';
+    output = '<script type=module>console.log(1)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // Full-form attribute value
+    input = '<script type="module">let bar=2;console.log(bar)</script>';
+    output = '<script type="module">console.log(2)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // Classic script: unused variable must be preserved (no `module:true`)
+    input = '<script>let baz=3;console.log(baz)</script>';
+    output = '<script>let baz=3;console.log(baz)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // User-supplied module:true in config is not overridden (still works)
+    input = '<script type=module>let qux=4;console.log(qux)</script>';
+    output = '<script type=module>console.log(4)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { module: true } }), output);
+
+    // SWC engine also applies `module:true` for `type=module` scripts
+    input = '<script type=module>let foo=1;console.log(foo)</script>';
+    output = '<script type=module>console.log(1)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
+
+    // SWC: Classic script does not apply `module:true`
+    input = '<script>let baz=3;console.log(baz)</script>';
+    output = '<script>let baz=3;console.log(baz)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
+  });
+
   test('JavaScript minification error handling', async () => {
     // Test invalid JavaScript syntax
     let input = '<script>function foo( { syntax error</script>';


### PR DESCRIPTION
Resolves #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Minifier now automatically enables ES-module-specific optimizations for <script type="module">, improving code reduction for modular JavaScript.
  * Classic scripts without type="module" remain unaffected.

* **Tests**
  * Added tests verifying module vs. classic script minification behaviors and engine-specific handling.

* **Chore/Docs**
  * Bumped package version to 6.1.0 and added changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->