### PR TITLE
Correct `mergeScripts` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-04-07
+
+### Fixed
+
+* `mergeScripts` no longer merges `<script type=module>` elements (each module has its own lexical scope, so merging can produce syntax errors) or other non-JS script types like `application/json` (whose content is not concatenable)
+
 ## [6.1.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* `mergeScripts` no longer merges `<script type=module>` elements (each module has its own lexical scope, so merging can produce syntax errors) or other non-JS script types like `application/json` (whose content is not concatenable)
+* Fixed `mergeScripts` to no longer merge `<script type=module>` elements (each module has its own lexical scope, so merging can produce syntax errors) or other non-JS script types like `application/json` (whose content is not concatenable)
 
 ## [6.1.0] - 2026-04-07
 
 ### Added
 
-* `<script type=module>` now automatically enables Terser’s and SWC’s `module: true` option, unlocking ES module–specific optimizations (e.g., unused variable elimination) that are only safe in module scope; classic scripts are unaffected
+* Updated `<script type=module>` to automatically enable Terser’s and SWC’s `module: true` option, unlocking ES module–specific optimizations (e.g., unused variable elimination) that are only safe in module scope; classic scripts are unaffected
 
 ## [6.0.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [6.1.0] - 2026-04-07
 
-### Added
+### Changed
 
 * Updated `<script type=module>` to automatically enable Terser’s and SWC’s `module: true` option, unlocking ES module–specific optimizations (e.g., unused variable elimination) that are only safe in module scope; classic scripts are unaffected
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.1.0"
+  "version": "6.1.1"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -181,8 +181,8 @@ function mergeConsecutiveScripts(html) {
       }
 
       // Check `type` compatibility (both must be default JS)
-      const type1 = a1.type || '';
-      const type2 = a2.type || '';
+      const type1 = (a1.type || '').toLowerCase();
+      const type2 = (a2.type || '').toLowerCase();
 
       if (DEFAULT_JS_TYPES.has(type1) && DEFAULT_JS_TYPES.has(type2)) {
         // Both are default JavaScript—compatible

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -180,16 +180,16 @@ function mergeConsecutiveScripts(html) {
         return match;
       }
 
-      // Check `type` compatibility (both must be same, or both default JS)
+      // Check `type` compatibility (both must be default JS)
       const type1 = a1.type || '';
       const type2 = a2.type || '';
 
       if (DEFAULT_JS_TYPES.has(type1) && DEFAULT_JS_TYPES.has(type2)) {
         // Both are default JavaScript—compatible
-      } else if (type1 === type2) {
-        // Same explicit type—compatible
       } else {
-        // Incompatible types
+        // Non-JS types (modules, JSON, etc.) must not be merged:
+        // Module scripts have per-script lexical scope, and non-JS content (e.g., JSON)
+        // is not concatenable. Even identical non-JS types are incompatible.
         return match;
       }
 

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -233,7 +233,7 @@ describe('CSS and JS', () => {
     await assert.doesNotReject(minify(input, { continueOnMinifyError: false, minifyCSS: true }));
   });
 
-  // Tests for minifyJS configuration options
+  // Tests for `minifyJS` configuration options
   test('JS: Basic boolean true', async () => {
     const input = '<script>function myFunction() { var x = 1; return x; }</script>';
     const output = '<script>function myFunction(){return 1}</script>';
@@ -312,6 +312,70 @@ describe('CSS and JS', () => {
 
     assert.ok(result.includes('myVar'), 'Variable names should not be mangled');
     assert.ok(result.includes('alert'), 'Function call should be preserved');
+  });
+
+  test('JS: MIME types that trigger minification', async () => {
+    let input, output;
+
+    input = '<script type="">function f(){  return 1  }</script>';
+    output = '<script type="">function f(){return 1}</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    input = '<script type="text/javascript">function f(){  return 1  }</script>';
+    output = '<script type="text/javascript">function f(){return 1}</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    input = '<script foo="bar">function f(){  return 1  }</script>';
+    output = '<script foo="bar">function f(){return 1}</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    input = '<script type="text/ecmascript">function f(){  return 1  }</script>';
+    output = '<script type="text/ecmascript">function f(){return 1}</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    input = '<script type="application/javascript">function f(){  return 1  }</script>';
+    output = '<script type="application/javascript">function f(){return 1}</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    input = '<script type="boo">function f(){  return 1  }</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), input);
+
+    input = '<script type="text/html"><!-- ko if: true -->\n\n\n<div></div>\n\n\n<!-- /ko --></script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), input);
+  });
+
+  test('JS: `type=module` enables module-specific optimizations', async () => {
+    let input, output;
+
+    // Module-specific optimization: unused variable elimination (only safe in module scope)
+    input = '<script type=module>let foo=1;console.log(foo)</script>';
+    output = '<script type=module>console.log(1)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // Full-form attribute value
+    input = '<script type="module">let bar=2;console.log(bar)</script>';
+    output = '<script type="module">console.log(2)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // Classic script: unused variable must be preserved (no `module:true`)
+    input = '<script>let baz=3;console.log(baz)</script>';
+    output = '<script>let baz=3;console.log(baz)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: true }), output);
+
+    // User-supplied module:true in config is not overridden (still works)
+    input = '<script type=module>let qux=4;console.log(qux)</script>';
+    output = '<script type=module>console.log(4)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { module: true } }), output);
+
+    // SWC engine also applies `module:true` for `type=module` scripts
+    input = '<script type=module>let foo=1;console.log(foo)</script>';
+    output = '<script type=module>console.log(1)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
+
+    // SWC: Classic script does not apply `module:true`
+    input = '<script>let baz=3;console.log(baz)</script>';
+    output = '<script>let baz=3;console.log(baz)</script>';
+    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
   });
 
   // Engine field tests
@@ -424,40 +488,6 @@ describe('CSS and JS', () => {
 
     assert.strictEqual(result1, result2, 'Case variations should produce same result');
     assert.strictEqual(result2, result3, 'Case variations should produce same result');
-  });
-
-  test('JS: `type=module` enables module-specific optimizations', async () => {
-    let input, output;
-
-    // Module-specific optimization: unused variable elimination (only safe in module scope)
-    input = '<script type=module>let foo=1;console.log(foo)</script>';
-    output = '<script type=module>console.log(1)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    // Full-form attribute value
-    input = '<script type="module">let bar=2;console.log(bar)</script>';
-    output = '<script type="module">console.log(2)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    // Classic script: unused variable must be preserved (no `module:true`)
-    input = '<script>let baz=3;console.log(baz)</script>';
-    output = '<script>let baz=3;console.log(baz)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    // User-supplied module:true in config is not overridden (still works)
-    input = '<script type=module>let qux=4;console.log(qux)</script>';
-    output = '<script type=module>console.log(4)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: { module: true } }), output);
-
-    // SWC engine also applies `module:true` for `type=module` scripts
-    input = '<script type=module>let foo=1;console.log(foo)</script>';
-    output = '<script type=module>console.log(1)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
-
-    // SWC: Classic script does not apply `module:true`
-    input = '<script>let baz=3;console.log(baz)</script>';
-    output = '<script>let baz=3;console.log(baz)</script>';
-    assert.strictEqual(await minify(input, { minifyJS: { engine: 'swc' } }), output);
   });
 
   test('JavaScript minification error handling', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2511,36 +2511,6 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, { minifyJS: true }), output);
   });
 
-  test('Minification of scripts with different MIME types', async () => {
-    let input, output;
-
-    input = '<script type="">function f(){  return 1  }</script>';
-    output = '<script type="">function f(){return 1}</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    input = '<script type="text/javascript">function f(){  return 1  }</script>';
-    output = '<script type="text/javascript">function f(){return 1}</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    input = '<script foo="bar">function f(){  return 1  }</script>';
-    output = '<script foo="bar">function f(){return 1}</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    input = '<script type="text/ecmascript">function f(){  return 1  }</script>';
-    output = '<script type="text/ecmascript">function f(){return 1}</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    input = '<script type="application/javascript">function f(){  return 1  }</script>';
-    output = '<script type="application/javascript">function f(){return 1}</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), output);
-
-    input = '<script type="boo">function f(){  return 1  }</script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), input);
-
-    input = '<script type="text/html"><!-- ko if: true -->\n\n\n<div></div>\n\n\n<!-- /ko --></script>';
-    assert.strictEqual(await minify(input, { minifyJS: true }), input);
-  });
-
   test('Minification of scripts with custom fragments', async () => {
     let input, output;
 

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2773,10 +2773,17 @@ describe('HTML', () => {
     input = '<script type="application/json">{"a":1}</script><script>var b=2</script>';
     assert.strictEqual(await minify(input, { mergeScripts: true }), input);
 
-    // Merge scripts with same `type` attribute
+    // Do not merge module scripts—each has its own lexical scope, so merging
+    // can cause errors (e.g., duplicate `let` declarations across modules)
     input = '<script type="module">var a=1</script><script type="module">var b=2</script>';
-    output = '<script type="module">var a=1;var b=2</script>';
-    assert.strictEqual(await minify(input, { mergeScripts: true }), output);
+    assert.strictEqual(await minify(input, { mergeScripts: true }), input);
+
+    // Do not merge same non-JS types—content is not concatenable
+    input = '<script type="application/json">{"a":1}</script><script type="application/json">{"b":2}</script>';
+    assert.strictEqual(await minify(input, { mergeScripts: true }), input);
+
+    input = '<script type="application/ld+json">{"@type":"Thing"}</script><script type="application/ld+json">{"@type":"Person"}</script>';
+    assert.strictEqual(await minify(input, { mergeScripts: true }), input);
 
     // Merge scripts where both have default JS type (explicit vs implicit)
     input = '<script type="text/javascript">var a=1</script><script>var b=2</script>';


### PR DESCRIPTION
Resolves #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script merging to prevent combining `<script type="module">` elements and non-JavaScript script types (e.g., `application/json`).

* **Changed**
  * Updated module script optimization settings for Terser/SWC to enable module-scoped optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->