### PR TITLE
Fix `continueOnParseError` incorrectly handling unquoted attribute values that contain `=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.3] - 2026-04-23
+
+### Fixed
+
+* Fixed `continueOnParseError` incorrectly handling unquoted attribute values that contain `=` (e.g., `href=?b=c`): the parser now includes `=` in the value per WHATWG error-recovery rules, preserving tag structure and the closing tag instead of dropping it
+
 ## [6.1.2] - 2026-04-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.1.2"
+  "version": "6.1.3"
 }

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -32,9 +32,12 @@ const singleAttrValues = [
   /"([^"]*)"+/.source,
   // Attr value, single quotes
   /'([^']*)'+/.source,
-  // Attr value, no quotes
+  // Attr value, no quotes (strict: excludes `=` per HTML spec)
   /([^ \t\n\f\r"'`=<>]+)/.source
 ];
+// Lenient unquoted value pattern for `continueOnParseError`: allows `=` per error-recovery rules
+// (unexpected-character-in-unquoted-attribute-value is a parse error but the char is included in the value)
+const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'`<>]+)/.source;
 // https://www.w3.org/TR/1999/REC-xml-names-19990114/#NT-QName
 const qnameCapture = (function () {
   // https://www.npmjs.com/package/ncname
@@ -100,9 +103,11 @@ function stripDelimited(str, open, close) {
 }
 
 function buildAttrRegex(handler) {
+  const unquotedValue = handler.continueOnParseError ? singleAttrValueLenientUnquoted : singleAttrValues[2];
+  const attrValues = [singleAttrValues[0], singleAttrValues[1], unquotedValue];
   let pattern = singleAttrIdentifier.source +
     '(?:\\s*(' + joinSingleAttrAssigns(handler) + ')' +
-    '[ \\t\\n\\f\\r]*(?:' + singleAttrValues.join('|') + '))?';
+    '[ \\t\\n\\f\\r]*(?:' + attrValues.join('|') + '))?';
   if (handler.customAttrSurround) {
     const attrClauses = [];
     for (let i = handler.customAttrSurround.length - 1; i >= 0; i--) {

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -35,9 +35,11 @@ const singleAttrValues = [
   // Attr value, no quotes (strict: excludes `=` per HTML spec)
   /([^ \t\n\f\r"'`=<>]+)/.source
 ];
-// Lenient unquoted value pattern for `continueOnParseError`: allows `=` per error-recovery rules
-// (unexpected-character-in-unquoted-attribute-value is a parse error but the char is included in the value)
-const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'`<>]+)/.source;
+// Lenient unquoted value pattern for `continueOnParseError`:
+// allows `=` and `` ` `` per spec error-recovery rules
+// (both are parse errors in unquoted-attribute-value state but appended to the value)
+// `"` and `'` remain excluded—permitting them requires broader test coverage
+const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'<>]+)/.source;
 // https://www.w3.org/TR/1999/REC-xml-names-19990114/#NT-QName
 const qnameCapture = (function () {
   // https://www.npmjs.com/package/ncname

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -156,6 +156,45 @@ describe('HTML', () => {
     assert.ok(output, 'Should produce output when continueOnParseError is true');
   });
 
+  // https://github.com/j9t/html-minifier-next/issues/257
+  test('Parse error recovery: `=` in unquoted attribute value', async () => {
+    // Without the flag, must throw
+    await assert.rejects(
+      () => minify('<a href=?b=c>d</a>e'),
+      { name: 'Error' }
+    );
+
+    // With `continueOnParseError`, the tag should be parsed (`=` included in value), structure preserved
+    assert.strictEqual(
+      await minify('<a href=?b=c>d</a>e', { continueOnParseError: true }),
+      '<a href="?b=c">d</a>e'
+    );
+
+    // Same with `decodeEntities`—closing tag must not be dropped
+    assert.strictEqual(
+      await minify('<a href=?b=c>d</a>e', { continueOnParseError: true, decodeEntities: true }),
+      '<a href="?b=c">d</a>e'
+    );
+
+    // Value with `=` cannot be unquoted, so `removeAttributeQuotes` must still quote it
+    assert.strictEqual(
+      await minify('<a href=?b=c>d</a>e', { continueOnParseError: true, removeAttributeQuotes: true }),
+      '<a href="?b=c">d</a>e'
+    );
+
+    // Multiple `=` signs in the value
+    assert.strictEqual(
+      await minify('<a href=?a=1&amp;b=2>d</a>e', { continueOnParseError: true }),
+      '<a href="?a=1&amp;b=2">d</a>e'
+    );
+
+    // Surrounding markup must be unaffected
+    assert.strictEqual(
+      await minify('<p>before</p><a href=?b=c>d</a><p>after</p>', { continueOnParseError: true }),
+      '<p>before</p><a href="?b=c">d</a><p>after</p>'
+    );
+  });
+
   test('Options', async () => {
     const input = '<p>blah<span>blah 2<span>blah 3</span></span></p>';
     assert.strictEqual(await minify(input), input);


### PR DESCRIPTION
Resolves #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `continueOnParseError` mode incorrectly dropped closing tags when unquoted attribute values contained `=` characters. The parser now correctly preserves tag structure and includes the `=` in the attribute value per error-recovery specifications.

* **Tests**
  * Added comprehensive regression tests for parse error recovery, verifying correct handling of special characters in unquoted attribute values and interaction with related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->