### PR TITLE
Extend `continueOnParseError` error recovery to also include `<`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.4] - 2026-04-24
+
+### Fixed
+
+* Extended `continueOnParseError` error recovery to also include `<` in unquoted attribute values (e.g., `href=foo<bar`), consistent with HTML error-recovery rules and matching the treatment of `=` and ``` added in 6.1.3
+
 ## [6.1.3] - 2026-04-23
 
 ### Fixed
 
-* Fixed `continueOnParseError` incorrectly handling unquoted attribute values that contain `=` (e.g., `href=?b=c`): the parser now includes `=` in the value per WHATWG error-recovery rules, preserving tag structure and the closing tag instead of dropping it
+* Fixed `continueOnParseError` incorrectly handling unquoted attribute values that contain `=` (e.g., `href=?b=c`): the parser now includes `=` in the value per HTML error-recovery rules, preserving tag structure and the closing tag instead of dropping it
 
 ## [6.1.2] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Extended `continueOnParseError` error recovery to also include `<` in unquoted attribute values (e.g., `href=foo<bar`), consistent with HTML error-recovery rules and matching the treatment of `=` and ``` added in 6.1.3
+* Extended `continueOnParseError` error recovery to also include `<` in unquoted attribute values (e.g., `href=foo<bar`), consistent with HTML error-recovery rules and matching the treatment of `=` and ````` added in 6.1.3
 
 ## [6.1.3] - 2026-04-23
 
 ### Fixed
 
-* Fixed `continueOnParseError` incorrectly handling unquoted attribute values that contain `=` (e.g., `href=?b=c`): the parser now includes `=` in the value per HTML error-recovery rules, preserving tag structure and the closing tag instead of dropping it
+* Fixed `continueOnParseError` incorrectly handling unquoted attribute values that contain `=` (e.g., `href=?b=c`)—the parser now includes `=` (as well as `````) in the value per HTML error-recovery rules, preserving tag structure and the closing tag instead of dropping it
 
 ## [6.1.2] - 2026-04-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.1.3"
+  "version": "6.1.4"
 }

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -36,10 +36,10 @@ const singleAttrValues = [
   /([^ \t\n\f\r"'`=<>]+)/.source
 ];
 // Lenient unquoted value pattern for `continueOnParseError`:
-// allows `=` and ``` per spec error-recovery rules
-// (both are parse errors in unquoted-attribute-value state but appended to the value)
+// allows `<`, `=`, and ``` per HTML error-recovery rules
+// (all are parse errors in unquoted-attribute-value state but appended to the value)
 // `"` and `'` remain excluded—permitting them requires broader test coverage
-const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'<>]+)/.source;
+const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'>]+)/.source;
 // https://www.w3.org/TR/1999/REC-xml-names-19990114/#NT-QName
 const qnameCapture = (function () {
   // https://www.npmjs.com/package/ncname

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -36,7 +36,7 @@ const singleAttrValues = [
   /([^ \t\n\f\r"'`=<>]+)/.source
 ];
 // Lenient unquoted value pattern for `continueOnParseError`:
-// allows `=` and `` ` `` per spec error-recovery rules
+// allows `=` and ``` per spec error-recovery rules
 // (both are parse errors in unquoted-attribute-value state but appended to the value)
 // `"` and `'` remain excluded—permitting them requires broader test coverage
 const singleAttrValueLenientUnquoted = /([^ \t\n\f\r"'<>]+)/.source;

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -195,6 +195,45 @@ describe('HTML', () => {
     );
   });
 
+  // https://github.com/j9t/html-minifier-next/issues/257
+  test('Parse error recovery: `<` in unquoted attribute value', async () => {
+    // Without the flag, must throw
+    await assert.rejects(
+      () => minify('<a href=foo<bar>d</a>e'),
+      { name: 'Error' }
+    );
+
+    // With `continueOnParseError`, `<` is included in value per HTML error-recovery rules
+    assert.strictEqual(
+      await minify('<a href=foo<bar>d</a>e', { continueOnParseError: true }),
+      '<a href="foo<bar">d</a>e'
+    );
+
+    // `<` at the start of a value
+    assert.strictEqual(
+      await minify('<a href=<bar>d</a>e', { continueOnParseError: true }),
+      '<a href="<bar">d</a>e'
+    );
+
+    // Same with `decodeEntities`—closing tag must not be dropped
+    assert.strictEqual(
+      await minify('<a href=foo<bar>d</a>e', { continueOnParseError: true, decodeEntities: true }),
+      '<a href="foo<bar">d</a>e'
+    );
+
+    // Value with `<` cannot be unquoted, so `removeAttributeQuotes` must still quote it
+    assert.strictEqual(
+      await minify('<a href=foo<bar>d</a>e', { continueOnParseError: true, removeAttributeQuotes: true }),
+      '<a href="foo<bar">d</a>e'
+    );
+
+    // Surrounding markup must be unaffected
+    assert.strictEqual(
+      await minify('<p>before</p><a href=foo<bar>d</a><p>after</p>', { continueOnParseError: true }),
+      '<p>before</p><a href="foo<bar">d</a><p>after</p>'
+    );
+  });
+
   test('Options', async () => {
     const input = '<p>blah<span>blah 2<span>blah 3</span></span></p>';
     assert.strictEqual(await minify(input), input);

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -234,6 +234,39 @@ describe('HTML', () => {
     );
   });
 
+  // https://github.com/j9t/html-minifier-next/issues/257
+  test('Parse error recovery: ``` in unquoted attribute value', async () => {
+    // Backtick at start of value: Strict mode throws
+    await assert.rejects(
+      () => minify('<a href=`bar>d</a>e'),
+      { name: 'Error' }
+    );
+
+    // With `continueOnParseError`, ``` is included in value per HTML error-recovery rules
+    assert.strictEqual(
+      await minify('<a href=`bar>d</a>e', { continueOnParseError: true }),
+      '<a href="`bar">d</a>e'
+    );
+
+    // Backtick in the middle of a value (strict mis-parses it as a separate attribute)
+    assert.strictEqual(
+      await minify('<a href=foo`bar>d</a>e', { continueOnParseError: true }),
+      '<a href="foo`bar">d</a>e'
+    );
+
+    // Value with ``` cannot be unquoted, so `removeAttributeQuotes` must still quote it
+    assert.strictEqual(
+      await minify('<a href=`bar>d</a>e', { continueOnParseError: true, removeAttributeQuotes: true }),
+      '<a href="`bar">d</a>e'
+    );
+
+    // Surrounding markup must be unaffected
+    assert.strictEqual(
+      await minify('<p>before</p><a href=`bar>d</a><p>after</p>', { continueOnParseError: true }),
+      '<p>before</p><a href="`bar">d</a><p>after</p>'
+    );
+  });
+
   test('Options', async () => {
     const input = '<p>blah<span>blah 2<span>blah 3</span></span></p>';
     assert.strictEqual(await minify(input), input);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error recovery for unquoted HTML attribute values containing the `<` character. When using the `continueOnParseError` option, the parser now properly handles malformed attribute declarations with `<` characters, correctly preserves content within attribute values, maintains the integrity of adjacent markup structures, and aligns error-recovery behavior with standard HTML specifications. Version bumped to 6.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->