### PR TITLE
Ensure support for boolean flag negation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2026-04-24
+
+### Added
+
+* Implemented every boolean CLI option to support both `--option-name` (enable) and `--no-option-name` (disable), making it possible to override any option set by a preset or config file from the command line—e.g., `--preset=comprehensive --no-collapse-whitespace`
+* Added the positive CLI form `--continue-on-minify-error` (the `continueOnMinifyError` option defaults to `true`; the flag is useful for overriding a config or preset that disables it)
+
+### Fixed
+
+* Fixed `--no-newlines-before-tag-close` being silently ignored due to a Commander.js key mismatch: the flag is now correctly applied
+
 ## [6.1.5] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Implemented every boolean CLI option to support both `--option-name` (enable) and `--no-option-name` (disable), making it possible to override any option set by a preset or config file from the command line—e.g., `--preset=comprehensive --no-collapse-whitespace`
+* Implemented boolean CLI options to support both `--option-name` (enable) and `--no-option-name` (disable), making it possible to override any option set by a preset or config file from the command line—e.g., `--preset=comprehensive --no-collapse-whitespace` (exception: `noNewlinesBeforeTagClose` already exposes only `--no-newlines-before-tag-close`, so no additional `--no-no-…` form is registered)
 * Added the positive CLI form `--continue-on-minify-error` (the `continueOnMinifyError` option defaults to `true`; the flag is useful for overriding a config or preset that disables it)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ html-minifier-next --preset conservative --remove-empty-attributes input.html
 
 Most of the options are disabled by default. Experiment and find what works best for you and your project.
 
-Options can be used in config files (camelCase) or via CLI flags (kebab-case with `--` prefix). Options that default to `true` use `--no-` prefix in CLI to disable them.
+Options can be used in config files (camelCase) or via CLI flags (kebab-case with `--` prefix). Every boolean option supports both `--option-name` to enable and `--no-option-name` to disable, so you can always override a preset or config file from the command line.
 
 | Option (config/CLI) | Description | Default |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ html-minifier-next --preset conservative --remove-empty-attributes input.html
 
 Most of the options are disabled by default. Experiment and find what works best for you and your project.
 
-Options can be used in config files (camelCase) or via CLI flags (kebab-case with `--` prefix). Every boolean option supports both `--option-name` to enable and `--no-option-name` to disable, so you can always override a preset or config file from the command line.
+Options can be used in config files (camelCase) or via CLI flags (kebab-case with `--` prefix). Boolean options generally support both `--option-name` to enable and `--no-option-name` to disable, so you can override a preset or config file from the command line. (Exception: Options whose name already starts with `no-`, such as `noNewlinesBeforeTagClose`, only expose the `--no-…` CLI flag.)
 
 | Option (config/CLI) | Description | Default |
 | --- | --- | --- |
@@ -142,7 +142,7 @@ Options can be used in config files (camelCase) or via CLI flags (kebab-case wit
 | `collapseInlineTagWhitespace`<br>`--collapse-inline-tag-whitespace` | Collapse whitespace more aggressively between inline elements—use with `collapseWhitespace: true` | `false` |
 | `collapseWhitespace`<br>`--collapse-whitespace` | [Collapse whitespace that contributes to text nodes in a document tree](https://perfectionkills.com/experimenting-with-html-minifier/#collapse_whitespace) | `false` |
 | `conservativeCollapse`<br>`--conservative-collapse` | Always collapse to one space (never remove it entirely)—use with `collapseWhitespace: true` | `false` |
-| `continueOnMinifyError`<br>`--no-continue-on-minify-error` | Continue on minification errors; when `false`, minification errors throw and abort processing | `true` |
+| `continueOnMinifyError`<br>`--continue-on-minify-error`<br>`--no-continue-on-minify-error` | Continue on minification errors; when `false`, minification errors throw and abort processing | `true` |
 | `continueOnParseError`<br>`--continue-on-parse-error` | [Handle parse errors](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors) instead of aborting | `false` |
 | `customAttrAssign`<br>`--custom-attr-assign` | Array of regexes that allow to support custom attribute assign expressions (e.g., `<div flex?="{{mode != cover}}"></div>`) | `[]` |
 | `customAttrCollapse`<br>`--custom-attr-collapse` | Regex that specifies custom attribute to strip newlines from (e.g., `/ng-class/`) | `undefined` |

--- a/cli.js
+++ b/cli.js
@@ -44,8 +44,8 @@ const camelCase = (str) => paramCase(str).replace(/-([a-z])/g, (_, c) => c.toUpp
 // stripping a leading `no-` first for negated flags (e.g., `--no-foo-bar` → `fooBar`);
 // because option definition keys may differ from the result of that round-trip (e.g.,
 // `minifyURLs` → Commander key `minifyUrls`, `noNewlinesBeforeTagClose` → `newlinesBeforeTagClose`),
-// `commanderOptKey` uses the same paramCase + camelCase path to compute the key Commander will use
-const commanderOptKey = (key) => {
+// `commanderOptionKey` uses the same paramCase + camelCase path to compute the key Commander will use
+const commanderOptionKey = (key) => {
   const pc = paramCase(key);
   return pc.startsWith('no-') ? camelCase(pc.slice(3)) : camelCase(pc);
 };
@@ -150,12 +150,12 @@ const typeParsers = {
 // Configure command-line flags from shared option definitions
 const mainOptionKeys = Object.keys(optionDefinitions);
 mainOptionKeys.forEach(function (key) {
-  const { description, positiveDescription, type } = optionDefinitions[key];
+  const { description, descriptionAffirmative, type } = optionDefinitions[key];
   const flag = paramCase(key);
   if (type === 'invertedBoolean') {
     // The positive form (to re-enable after a preset/config disables it) is hidden from
     // help—the footer note covers the convention; the negative form is the primary use case
-    program.addOption(new Option('--' + flag, positiveDescription ?? 'Enable --' + flag).hideHelp());
+    program.addOption(new Option('--' + flag, descriptionAffirmative ?? 'Enable --' + flag).hideHelp());
     program.option('--no-' + flag, description);
   } else if (type === 'boolean') {
     program.option('--' + flag, description);
@@ -420,7 +420,7 @@ program.helpOption('-h, --help', 'Display help for command');
     // 3. Apply CLI options (overrides config and preset)
     mainOptionKeys.forEach(function (key) {
       const { type } = optionDefinitions[key];
-      const ck = commanderOptKey(key);
+      const ck = commanderOptionKey(key);
       if (program.getOptionValueSource(ck) === 'cli') {
         const val = programOptions[ck];
         // For boolean options whose param-case name starts with `no-`, Commander treats
@@ -439,7 +439,7 @@ program.helpOption('-h, --help', 'Display help for command');
       console.error(`Using preset: ${presetName}`);
     }
     const activeOptions = Object.entries(minifierOptions)
-      .filter(([k]) => program.getOptionValueSource(commanderOptKey(k)) === 'cli')
+      .filter(([k]) => program.getOptionValueSource(commanderOptionKey(k)) === 'cli')
       .map(([k, v]) => (typeof v === 'boolean' ? (v ? k : `no-${k}`) : k));
     if (activeOptions.length > 0) {
       console.error('CLI options: ' + activeOptions.join(', '));

--- a/cli.js
+++ b/cli.js
@@ -40,10 +40,11 @@ import { Command } from 'commander';
 const paramCase = (str) => str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 const camelCase = (str) => paramCase(str).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
 
-// Commander always derives its internal option key by camelCasing the param-case flag name,
-// stripping a leading `no-` first when the flag is a negation (e.g., `--no-foo-bar` → `fooBar`);
-// option definition keys may differ from this (e.g., `minifyURLs` → Commander key `minifyUrls`,
-// Commander key the same way Commander does
+// Commander derives its internal option key by applying paramCase then camelCase to the flag name,
+// stripping a leading `no-` first for negated flags (e.g., `--no-foo-bar` → `fooBar`);
+// because option definition keys may differ from the result of that round-trip (e.g.,
+// `minifyURLs` → Commander key `minifyUrls`, `noNewlinesBeforeTagClose` → `newlinesBeforeTagClose`),
+// `commanderOptKey` uses the same paramCase + camelCase path to compute the key Commander will use
 const commanderOptKey = (key) => {
   const pc = paramCase(key);
   return pc.startsWith('no-') ? camelCase(pc.slice(3)) : camelCase(pc);
@@ -149,12 +150,12 @@ const typeParsers = {
 // Configure command-line flags from shared option definitions
 const mainOptionKeys = Object.keys(optionDefinitions);
 mainOptionKeys.forEach(function (key) {
-  const { description, type } = optionDefinitions[key];
+  const { description, positiveDescription, type } = optionDefinitions[key];
   const flag = paramCase(key);
   if (type === 'invertedBoolean') {
     // Add both the positive form (to re-enable after a preset/config disables it)
-    // and the existing negative form (the primary way to disable a default-true option)
-    program.option('--' + flag, 'Continue on minification errors');
+    // and the existing negative form (the primary way to disable a default-true option).
+    program.option('--' + flag, positiveDescription ?? 'Enable --' + flag);
     program.option('--no-' + flag, description);
   } else if (type === 'boolean') {
     program.option('--' + flag, description);

--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,15 @@ import { Command } from 'commander';
 const paramCase = (str) => str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 const camelCase = (str) => paramCase(str).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
 
+// Commander always derives its internal option key by camelCasing the param-case flag name,
+// stripping a leading `no-` first when the flag is a negation (e.g., `--no-foo-bar` → `fooBar`);
+// option definition keys may differ from this (e.g., `minifyURLs` → Commander key `minifyUrls`,
+// Commander key the same way Commander does
+const commanderOptKey = (key) => {
+  const pc = paramCase(key);
+  return pc.startsWith('no-') ? camelCase(pc.slice(3)) : camelCase(pc);
+};
+
 // Lazy-load HMN to reduce CLI cold-start overhead
 import { getPreset, getPresetNames } from './src/presets.js';
 import { parseRegExp } from './src/lib/utils.js';
@@ -141,14 +150,24 @@ const typeParsers = {
 const mainOptionKeys = Object.keys(optionDefinitions);
 mainOptionKeys.forEach(function (key) {
   const { description, type } = optionDefinitions[key];
+  const flag = paramCase(key);
   if (type === 'invertedBoolean') {
-    program.option('--no-' + paramCase(key), description);
+    // Add both the positive form (to re-enable after a preset/config disables it)
+    // and the existing negative form (the primary way to disable a default-true option)
+    program.option('--' + flag, 'Continue on minification errors');
+    program.option('--no-' + flag, description);
   } else if (type === 'boolean') {
-    program.option('--' + paramCase(key), description);
+    program.option('--' + flag, description);
+    // Add the negation form so users can override a preset or config file that enabled
+    // the option; skip options whose flag already starts with `no-` (currently only
+    // `noNewlinesBeforeTagClose`), as `--no-no-X` is not usable
+    if (!flag.startsWith('no-')) {
+      program.option('--no-' + flag, 'Disable --' + flag);
+    }
   } else {
-    const flag = '--' + paramCase(key) + (type === 'json' ? ' [value]' : ' <value>');
+    const cliFlag = '--' + flag + (type === 'json' ? ' [value]' : ' <value>');
     const parser = type === 'int' ? typeParsers.int(key) : typeParsers[type];
-    program.option(flag, description, parser);
+    program.option(cliFlag, description, parser);
   }
 });
 program.option('-o --output <file>', 'Specify output file (reads from file arguments or STDIN; outputs to STDOUT if not specified)');
@@ -398,9 +417,14 @@ program.helpOption('-h, --help', 'Display help for command');
 
     // 3. Apply CLI options (overrides config and preset)
     mainOptionKeys.forEach(function (key) {
-      const param = programOptions[camelCase(key)];
-      if (typeof param !== 'undefined') {
-        options[key] = param;
+      const { type } = optionDefinitions[key];
+      const ck = commanderOptKey(key);
+      if (program.getOptionValueSource(ck) === 'cli') {
+        const val = programOptions[ck];
+        // For boolean options whose param-case name starts with `no-`, Commander treats
+        // the flag as a negation and stores the inverted value under the stripped key;
+        // invert back so the option definition key gets the intended value
+        options[key] = (type === 'boolean' && paramCase(key).startsWith('no-')) ? !val : val;
       }
     });
 
@@ -413,7 +437,7 @@ program.helpOption('-h, --help', 'Display help for command');
       console.error(`Using preset: ${presetName}`);
     }
     const activeOptions = Object.entries(minifierOptions)
-      .filter(([k]) => program.getOptionValueSource(camelCase(k)) === 'cli')
+      .filter(([k]) => program.getOptionValueSource(commanderOptKey(k)) === 'cli')
       .map(([k, v]) => (typeof v === 'boolean' ? (v ? k : `no-${k}`) : k));
     if (activeOptions.length > 0) {
       console.error('CLI options: ' + activeOptions.join(', '));

--- a/cli.js
+++ b/cli.js
@@ -34,7 +34,7 @@ import { pathToFileURL } from 'url';
 import os from 'os';
 import readline from 'readline';
 import { createRequire } from 'module';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 // Simple case conversion for CLI option names (ASCII-only, no Unicode needed)
 const paramCase = (str) => str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
@@ -153,17 +153,17 @@ mainOptionKeys.forEach(function (key) {
   const { description, positiveDescription, type } = optionDefinitions[key];
   const flag = paramCase(key);
   if (type === 'invertedBoolean') {
-    // Add both the positive form (to re-enable after a preset/config disables it)
-    // and the existing negative form (the primary way to disable a default-true option).
-    program.option('--' + flag, positiveDescription ?? 'Enable --' + flag);
+    // The positive form (to re-enable after a preset/config disables it) is hidden from
+    // help—the footer note covers the convention; the negative form is the primary use case
+    program.addOption(new Option('--' + flag, positiveDescription ?? 'Enable --' + flag).hideHelp());
     program.option('--no-' + flag, description);
   } else if (type === 'boolean') {
     program.option('--' + flag, description);
-    // Add the negation form so users can override a preset or config file that enabled
-    // the option; skip options whose flag already starts with `no-` (currently only
+    // The negation form is hidden from help—the footer note covers the convention;
+    // skip options whose flag already starts with `no-` (currently only
     // `noNewlinesBeforeTagClose`), as `--no-no-X` is not usable
     if (!flag.startsWith('no-')) {
-      program.option('--no-' + flag, 'Disable --' + flag);
+      program.addOption(new Option('--no-' + flag, 'Disable --' + flag).hideHelp());
     }
   } else {
     const cliFlag = '--' + flag + (type === 'json' ? ' [value]' : ' <value>');
@@ -174,6 +174,7 @@ mainOptionKeys.forEach(function (key) {
 program.option('-o --output <file>', 'Specify output file (reads from file arguments or STDIN; outputs to STDOUT if not specified)');
 program.option('-v --verbose', 'Show detailed processing information');
 program.option('-d --dry', 'Dry run: Process and report statistics without writing output');
+program.addHelpText('after', '\nBoolean options support a `--no-<flag>` form to disable them, overriding a preset or config file (e.g., `--preset=comprehensive --no-collapse-whitespace`).');
 
 // Lazy import wrapper for HMN
 let minifyFnPromise;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.1.5",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.1.5",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.1.5"
+  "version": "6.2.0"
 }

--- a/src/lib/option-definitions.js
+++ b/src/lib/option-definitions.js
@@ -27,7 +27,7 @@ const optionDefinitions = {
   },
   continueOnMinifyError: {
     description: 'Abort on minification errors',
-    positiveDescription: 'Continue on minification errors',
+    descriptionAffirmative: 'Continue on minification errors',
     type: 'invertedBoolean'
   },
   continueOnParseError: {

--- a/src/lib/option-definitions.js
+++ b/src/lib/option-definitions.js
@@ -27,6 +27,7 @@ const optionDefinitions = {
   },
   continueOnMinifyError: {
     description: 'Abort on minification errors',
+    positiveDescription: 'Continue on minification errors',
     type: 'invertedBoolean'
   },
   continueOnParseError: {

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -1504,15 +1504,17 @@ describe('CLI', () => {
   test('`--no-X` should override a boolean option enabled by a preset', () => {
     const input = '<p>  hello  </p>';
 
-    const { stdout: withPreset } = spawnSync('node', [cliPath, '--preset=comprehensive'], {
+    const { stdout: withPreset, status: presetStatus } = spawnSync('node', [cliPath, '--preset=comprehensive'], {
       cwd: fixturesDir,
       input
     });
-    const { stdout: withNegation } = spawnSync('node', [cliPath, '--preset=comprehensive', '--no-collapse-whitespace'], {
+    const { stdout: withNegation, status: negationStatus } = spawnSync('node', [cliPath, '--preset=comprehensive', '--no-collapse-whitespace'], {
       cwd: fixturesDir,
       input
     });
 
+    assert.strictEqual(presetStatus, 0);
+    assert.strictEqual(negationStatus, 0);
     // The comprehensive preset collapses whitespace (and removes optional tags like `</p>`)
     assert.strictEqual(withPreset.toString().trim(), '<p>hello');
     // `--no-collapse-whitespace` disables whitespace collapsing, so whitespace is preserved
@@ -1522,15 +1524,17 @@ describe('CLI', () => {
   test('`--no-X` should have no effect when the option is already disabled', () => {
     const input = '<p>  hello  </p>';
 
-    const { stdout: plain } = spawnSync('node', [cliPath], {
+    const { stdout: plain, status: plainStatus } = spawnSync('node', [cliPath], {
       cwd: fixturesDir,
       input
     });
-    const { stdout: withNegation } = spawnSync('node', [cliPath, '--no-collapse-whitespace'], {
+    const { stdout: withNegation, status: negationStatus } = spawnSync('node', [cliPath, '--no-collapse-whitespace'], {
       cwd: fixturesDir,
       input
     });
 
+    assert.strictEqual(plainStatus, 0);
+    assert.strictEqual(negationStatus, 0);
     // `collapseWhitespace` defaults to false, so `--no-collapse-whitespace` changes nothing
     assert.strictEqual(plain.toString().trim(), withNegation.toString().trim());
   });
@@ -1550,11 +1554,12 @@ describe('CLI', () => {
     const input = '<a title="x"href=" ">foo</a>';
     const expected = await minify(input, { maxLineLength: 25, noNewlinesBeforeTagClose: true });
 
-    const { stdout } = spawnSync('node', [cliPath, '--max-line-length=25', '--no-newlines-before-tag-close'], {
+    const { stdout, status } = spawnSync('node', [cliPath, '--max-line-length=25', '--no-newlines-before-tag-close'], {
       cwd: fixturesDir,
       input
     });
 
+    assert.strictEqual(status, 0);
     assert.strictEqual(stdout.toString().trim(), expected);
   });
 });

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -1515,10 +1515,12 @@ describe('CLI', () => {
 
     assert.strictEqual(presetStatus, 0);
     assert.strictEqual(negationStatus, 0);
-    // The comprehensive preset collapses whitespace (and removes optional tags like `</p>`)
-    assert.strictEqual(withPreset.toString().trim(), '<p>hello');
+    // The comprehensive preset collapses whitespace, so the original double spaces are gone
+    assert.ok(!withPreset.toString().includes('  hello  '));
     // `--no-collapse-whitespace` disables whitespace collapsing, so whitespace is preserved
     assert.ok(withNegation.toString().includes('  hello  '));
+    // The two runs therefore differ
+    assert.notStrictEqual(withPreset.toString().trim(), withNegation.toString().trim());
   });
 
   test('`--no-X` should have no effect when the option is already disabled', () => {

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -1499,4 +1499,62 @@ describe('CLI', () => {
     assert.ok(result.stderr.toString().includes('version control'));
     assert.ok(result.stderr.toString().includes('[y/N]'));
   });
+
+  // Boolean flag negation tests
+  test('`--no-X` should override a boolean option enabled by a preset', () => {
+    const input = '<p>  hello  </p>';
+
+    const { stdout: withPreset } = spawnSync('node', [cliPath, '--preset=comprehensive'], {
+      cwd: fixturesDir,
+      input
+    });
+    const { stdout: withNegation } = spawnSync('node', [cliPath, '--preset=comprehensive', '--no-collapse-whitespace'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    // The comprehensive preset collapses whitespace (and removes optional tags like `</p>`)
+    assert.strictEqual(withPreset.toString().trim(), '<p>hello');
+    // `--no-collapse-whitespace` disables whitespace collapsing, so whitespace is preserved
+    assert.ok(withNegation.toString().includes('  hello  '));
+  });
+
+  test('`--no-X` should have no effect when the option is already disabled', () => {
+    const input = '<p>  hello  </p>';
+
+    const { stdout: plain } = spawnSync('node', [cliPath], {
+      cwd: fixturesDir,
+      input
+    });
+    const { stdout: withNegation } = spawnSync('node', [cliPath, '--no-collapse-whitespace'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    // `collapseWhitespace` defaults to false, so `--no-collapse-whitespace` changes nothing
+    assert.strictEqual(plain.toString().trim(), withNegation.toString().trim());
+  });
+
+  test('`--continue-on-minify-error` should be recognized as the positive form of the flag', () => {
+    const input = '<p>test</p>';
+    const { stdout, status } = spawnSync('node', [cliPath, '--continue-on-minify-error'], {
+      cwd: fixturesDir,
+      input
+    });
+    assert.strictEqual(status, 0);
+    assert.strictEqual(stdout.toString().trim(), '<p>test</p>');
+  });
+
+  test('`--no-newlines-before-tag-close` should be applied and match the JS API', async () => {
+    // This flag was previously silently ignored due to a Commander key mismatch
+    const input = '<a title="x"href=" ">foo</a>';
+    const expected = await minify(input, { maxLineLength: 25, noNewlinesBeforeTagClose: true });
+
+    const { stdout } = spawnSync('node', [cliPath, '--max-line-length=25', '--no-newlines-before-tag-close'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    assert.strictEqual(stdout.toString().trim(), expected);
+  });
 });


### PR DESCRIPTION
Resolves #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI boolean options now accept both enable and disable forms (--option and --no-option) to override presets/config
  * Added a positive --continue-on-minify-error flag (matches default continue behavior)

* **Bug Fixes**
  * --no-newlines-before-tag-close is no longer silently ignored and is now applied correctly

* **Documentation**
  * Changelog and README updated for flag behavior and 6.2.0 release notes

* **Tests**
  * Added CLI tests for negation flags and continue-on-minify-error behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->