### PR TITLE
Add attribute whitespace exemptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fixed `collapseAttributeWhitespace` incorrectly collapsing whitespace in attributes where it is semantically significant: `pattern` (regex literal spaces, e.g., `\d  \d` matching exactly two spaces), `value` (pre-filled form field contents), `title` (line breaks and spacing render visibly in browser tooltips), `placeholder` (spaces render visibly in inputs), and event handler attributes (spaces inside string literals, e.g., `onclick="alert('→     ←')"`).
+* Fixed `collapseAttributeWhitespace` incorrectly collapsing whitespace in attributes where it is semantically significant:
+  - `pattern` (regex literal spaces, e.g., `\d  \d` matching exactly two spaces)
+  - `value` on form-submission elements (`input`, `option`, `button`, `data`, `param`) where the value is used verbatim—but not on numeric elements (like `li` or `meter`) where the browser normalizes it
+  - `title` (line breaks and spacing render visibly in browser tooltips)
+  - `placeholder` (spaces render visibly in inputs)
+  - event handler attributes (spaces inside string literals, e.g., `onclick="alert('→     ←')"`).
 
 ## [6.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fixed `collapseAttributeWhitespace` incorrectly collapsing whitespace in `pattern` attributes (where whitespace is semantically significant in the regex, e.g., `\d  \d` matching exactly two spaces) and `value` attributes (where whitespace may be intentional in pre-filled form field contents)
+* Fixed `collapseAttributeWhitespace` incorrectly collapsing whitespace in attributes where it is semantically significant: `pattern` (regex literal spaces, e.g., `\d  \d` matching exactly two spaces), `value` (pre-filled form field contents), `title` (line breaks and spacing render visibly in browser tooltips), `placeholder` (spaces render visibly in inputs), and event handler attributes (spaces inside string literals, e.g., `onclick="alert('→     ←')"`).
 
 ## [6.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.1] - 2026-04-30
+
+### Fixed
+
+* Fixed `collapseAttributeWhitespace` incorrectly collapsing whitespace in `pattern` attributes (where whitespace is semantically significant in the regex, e.g., `\d  \d` matching exactly two spaces) and `value` attributes (where whitespace may be intentional in pre-filled form field contents)
+
 ## [6.2.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.1] - 2026-04-30
+## [6.2.1] - 2026-05-01
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ Parameters:
 
 ## Acknowledgements
 
-With many thanks to all the previous authors of HTML Minifier, especially [Juriy “kangax” Zaytsev](https://github.com/kangax), and to everyone who helped make this new edition better, particularly [Daniel Ruf](https://github.com/DanielRuf) and [Jonas Geiler](https://github.com/jonasgeiler).
+With many thanks to the previous authors of and contributors to HTML Minifier, especially [Juriy “kangax” Zaytsev](https://github.com/kangax), and to everyone who helped make this new edition better, particularly [Daniel Ruf](https://github.com/DanielRuf), [Jonas Geiler](https://github.com/jonasgeiler), and [Chris Morgan](https://github.com/chris-morgan)!
 
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",
@@ -1858,7 +1858,7 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
       "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.0"
+  "version": "6.2.1"
 }

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -296,7 +296,7 @@ function hasAttrName(name, attrs) {
 
 const collapseAttributeWhitespaceExempt = new Set(['pattern', 'placeholder', 'title']);
 // `value` whitespace matters only on form-submission and machine-readable elements
-const valueWhitespaceExemptTags = new Set(['button', 'data', 'input', 'option', 'param']);
+const valueWhitespaceExemptElements = new Set(['button', 'data', 'input', 'option', 'param']);
 
 // Returns the cleaned attribute value directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
@@ -305,7 +305,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
 
   // Apply early whitespace normalization if enabled
   // Preserves special spaces (no-break space, hair space, etc.) for consistency with `collapseWhitespace`
-  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !(attrName === 'value' && valueWhitespaceExemptTags.has(tag)) && !isEventAttr) {
+  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !(attrName === 'value' && valueWhitespaceExemptElements.has(tag)) && !isEventAttr) {
     // Fast path: Only process if whitespace exists (avoids regex overhead on clean values)
     if (RE_ATTR_WS_CHECK.test(attrValue)) {
       // Two-pass approach (faster than single-pass with callback)

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -294,12 +294,14 @@ function hasAttrName(name, attrs) {
 
 // Cleaners
 
+const collapseAttributeWhitespaceExempt = new Set(['pattern', 'placeholder', 'title', 'value']);
+
 // Returns the cleaned attribute value directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
 function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTMLSelf) {
   // Apply early whitespace normalization if enabled
   // Preserves special spaces (no-break space, hair space, etc.) for consistency with `collapseWhitespace`
-  if (options.collapseAttributeWhitespace && attrName !== 'pattern' && attrName !== 'value') {
+  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !isEventAttribute(attrName, options)) {
     // Fast path: Only process if whitespace exists (avoids regex overhead on clean values)
     if (RE_ATTR_WS_CHECK.test(attrValue)) {
       // Two-pass approach (faster than single-pass with callback)

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -294,7 +294,9 @@ function hasAttrName(name, attrs) {
 
 // Cleaners
 
-const collapseAttributeWhitespaceExempt = new Set(['pattern', 'placeholder', 'title', 'value']);
+const collapseAttributeWhitespaceExempt = new Set(['pattern', 'placeholder', 'title']);
+// `value` whitespace matters only on form-submission and machine-readable elements
+const valueWhitespaceExemptTags = new Set(['button', 'data', 'input', 'option', 'param']);
 
 // Returns the cleaned attribute value directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
@@ -303,7 +305,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
 
   // Apply early whitespace normalization if enabled
   // Preserves special spaces (no-break space, hair space, etc.) for consistency with `collapseWhitespace`
-  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !isEventAttr) {
+  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !(attrName === 'value' && valueWhitespaceExemptTags.has(tag)) && !isEventAttr) {
     // Fast path: Only process if whitespace exists (avoids regex overhead on clean values)
     if (RE_ATTR_WS_CHECK.test(attrValue)) {
       // Two-pass approach (faster than single-pass with callback)

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -299,7 +299,7 @@ function hasAttrName(name, attrs) {
 function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTMLSelf) {
   // Apply early whitespace normalization if enabled
   // Preserves special spaces (no-break space, hair space, etc.) for consistency with `collapseWhitespace`
-  if (options.collapseAttributeWhitespace) {
+  if (options.collapseAttributeWhitespace && attrName !== 'pattern' && attrName !== 'value') {
     // Fast path: Only process if whitespace exists (avoids regex overhead on clean values)
     if (RE_ATTR_WS_CHECK.test(attrValue)) {
       // Two-pass approach (faster than single-pass with callback)

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -299,9 +299,11 @@ const collapseAttributeWhitespaceExempt = new Set(['pattern', 'placeholder', 'ti
 // Returns the cleaned attribute value directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
 function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTMLSelf) {
+  const isEventAttr = isEventAttribute(attrName, options);
+
   // Apply early whitespace normalization if enabled
   // Preserves special spaces (no-break space, hair space, etc.) for consistency with `collapseWhitespace`
-  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !isEventAttribute(attrName, options)) {
+  if (options.collapseAttributeWhitespace && !collapseAttributeWhitespaceExempt.has(attrName) && !isEventAttr) {
     // Fast path: Only process if whitespace exists (avoids regex overhead on clean values)
     if (RE_ATTR_WS_CHECK.test(attrValue)) {
       // Two-pass approach (faster than single-pass with callback)
@@ -311,7 +313,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
     }
   }
 
-  if (isEventAttribute(attrName, options)) {
+  if (isEventAttr) {
     attrValue = trimWhitespace(attrValue).replace(/^javascript:\s*/i, '');
     const result = options.minifyJS(attrValue, true);
     if (isThenable(result)) {

--- a/src/lib/whitespace.js
+++ b/src/lib/whitespace.js
@@ -211,15 +211,15 @@ function collapseWhitespaceSmart(str, prevTag, nextTag, prevAttrs, nextAttrs, op
 
 // Collapse/trim whitespace for given tag
 
-const noCollapseWsTags = new Set(['script', 'style', 'pre', 'textarea']);
-const noTrimWsTags = new Set(['pre', 'textarea']);
+const noCollapseWhitespaceTags = new Set(['script', 'style', 'pre', 'textarea']);
+const noTrimWhitespaceTags = new Set(['pre', 'textarea']);
 
 function canCollapseWhitespace(tag) {
-  return !noCollapseWsTags.has(tag);
+  return !noCollapseWhitespaceTags.has(tag);
 }
 
 function canTrimWhitespace(tag) {
-  return !noTrimWsTags.has(tag);
+  return !noTrimWhitespaceTags.has(tag);
 }
 
 // Exports

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -4366,11 +4366,20 @@ describe('HTML', () => {
     input = '<input pattern="  [a-z]+">';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
 
-    // `value` whitespace may be intentional (pre-filled form field contents), so it must not be touched
+    // `value` whitespace matters on form-submission elements (used verbatim) but not on numeric ones (browser-normalized)
     input = '<input value="  hello  ">';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
     input = '<input value="foo  bar">';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<option value="  foo  "></option>';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<button value="  foo  "></button>';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    // Numeric `value` attributes are browser-normalized, so collapsing is safe
+    input = '<li value=" 3 ">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), '<li value="3">');
+    input = '<meter value=" 0.5 " min="0" max="1"></meter>';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), '<meter value="0.5" min="0" max="1"></meter>');
 
     // `title` whitespace is significant (e.g., line breaks render as tooltip line breaks in browsers)
     input = '<div title="  hello world  "></div>';

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -4396,6 +4396,9 @@ describe('HTML', () => {
     // Event handler whitespace is significant (spaces inside JS string literals must not be collapsed)
     input = '<button onclick="alert(\'→     ←\')">x</button>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    // `on*` attributes are still JS-minified even when `collapseAttributeWhitespace` skips them;
+    // string-internal spaces survive because `minifyJS` preserves string literal contents
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true, minifyJS: true }), '<button onclick=\'alert("→     ←")\'>x</button>');
   });
 
   test('Decode entity characters', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -4295,8 +4295,8 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, { collapseWhitespace: true }), input);
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: false }), input);
 
-    // Should collapse with `collapseAttributeWhitespace: true`
-    output = '<article title="foo bar" data-selector="teaser-object parent-image-label picture-article" data-external-selector="teaser-object parent-image-label"></article>';
+    // Should collapse with `collapseAttributeWhitespace: true` (`title` is exempt)
+    output = '<article title="foo  bar" data-selector="teaser-object parent-image-label picture-article" data-external-selector="teaser-object parent-image-label"></article>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), output);
 
     // Multiple spaces in `alt` attribute
@@ -4312,11 +4312,10 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), output);
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true, minifyCSS: true }), output);
 
-    // Leading and trailing whitespace
+    // Leading and trailing whitespace (`title` is exempt, so whitespace is preserved)
     input = '<div title="  hello world  "></div>';
     assert.strictEqual(await minify(input), input);
-    output = '<div title="hello world"></div>';
-    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), output);
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
 
     // Should work with `sortClassNames` (correct alphabetical expectation)
     input = '<article class="lg:border-grey-700 lg:dark:border-grey-700-dark mb-[40px] cursor-pointer sm:mx-[40px] lg:flex lg:flex-row lg:border-[1px] lg:border-solid" data-selector="teaser-object parent-image-label picture-article" data-external-selector="\n      teaser-object parent-image-label \n        \n    "></article>';
@@ -4337,28 +4336,28 @@ describe('HTML', () => {
     input = '<p class="foo bar baz"></p>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
 
-    // Should work with `removeAttributeQuotes`
+    // Should work with `removeAttributeQuotes` (`title` is exempt; quotes are retained since spaces remain)
     input = '<p class=  foo title="  hello  world  "></p>';
-    output = '<p class=foo title="hello world"></p>';
+    output = '<p class=foo title="  hello  world  "></p>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true, removeAttributeQuotes: true }), output);
 
-    // Should work together with `collapseWhitespace` for both text nodes and attributes
+    // Should work together with `collapseWhitespace` for text nodes (`title` attribute is exempt)
     input = '<p title="  foo   bar  ">\n  Hello   \n  world  \n</p>';
-    output = '<p title="foo bar">Hello world</p>';
+    output = '<p title="  foo   bar  ">Hello world</p>';
     assert.strictEqual(await minify(input, { collapseWhitespace: true, collapseAttributeWhitespace: true }), output);
 
     // Special Unicode whitespace (hair space, no-break space) is preserved for consistency with `collapseWhitespace`
-    input = '<div title="foo\u200Abar  baz"></div>';
-    output = '<div title="foo\u200Abar baz"></div>';
+    input = '<div data-label="foo\u200Abar  baz"></div>';
+    output = '<div data-label="foo\u200Abar baz"></div>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), output);
 
     // No-break space is preserved (consistent with `collapseWhitespace` behavior in text nodes)
-    input = '<div title="foo\u00A0\u00A0bar"></div>';
+    input = '<div data-label="foo\u00A0\u00A0bar"></div>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
 
     // Special Unicode whitespace (hair space, no-break space) is preserved for consistency with `collapseWhitespace`
-    input = '<div title="foo\u200Abar  baz &nbsp; @&#8202;test"></div>';
-    output = '<div title="foo bar baz   @ test"></div>';
+    input = '<div data-label="foo\u200Abar  baz &nbsp; @&#8202;test"></div>';
+    output = '<div data-label="foo bar baz   @ test"></div>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true, decodeEntities: true }), output);
 
     // `pattern` whitespace is semantically significant (regex), so it must not be touched
@@ -4371,6 +4370,22 @@ describe('HTML', () => {
     input = '<input value="  hello  ">';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
     input = '<input value="foo  bar">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+
+    // `title` whitespace is significant (e.g., line breaks render as tooltip line breaks in browsers)
+    input = '<div title="  hello world  "></div>';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<abbr title="Foo  Bar\nBaz"></abbr>';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+
+    // `placeholder` whitespace is significant (leading spaces are visually rendered in inputs)
+    input = '<input placeholder="  enter name">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<input placeholder="first  last">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+
+    // Event handler whitespace is significant (spaces inside JS string literals must not be collapsed)
+    input = '<button onclick="alert(\'→     ←\')">x</button>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
   });
 

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -4360,6 +4360,18 @@ describe('HTML', () => {
     input = '<div title="foo\u200Abar  baz &nbsp; @&#8202;test"></div>';
     output = '<div title="foo bar baz   @ test"></div>';
     assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true, decodeEntities: true }), output);
+
+    // `pattern` whitespace is semantically significant (regex), so it must not be touched
+    input = '<input pattern="\\d  \\d">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<input pattern="  [a-z]+">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+
+    // `value` whitespace may be intentional (pre-filled form field contents), so it must not be touched
+    input = '<input value="  hello  ">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
+    input = '<input value="foo  bar">';
+    assert.strictEqual(await minify(input, { collapseAttributeWhitespace: true }), input);
   });
 
   test('Decode entity characters', async () => {

--- a/tests/svg+mathml.spec.js
+++ b/tests/svg+mathml.spec.js
@@ -284,8 +284,8 @@ describe('SVG and MathML', () => {
     assert.ok(noQuotes.includes('viewBox="0 0 100 100"'), 'SVG attribute quotes preserved');
 
     // `removeTagWhitespace` must not remove space between SVG attributes
-    const tagWs = await minify('<svg viewBox="0 0 100 100"><rect width="100" height="100" fill="red"/></svg>', { minifySVG: true, removeTagWhitespace: true, collapseWhitespace: true });
-    assert.ok(!tagWs.includes('width="100"height'), 'Whitespace between SVG attributes preserved');
+    const tagWhitespace = await minify('<svg viewBox="0 0 100 100"><rect width="100" height="100" fill="red"/></svg>', { minifySVG: true, removeTagWhitespace: true, collapseWhitespace: true });
+    assert.ok(!tagWhitespace.includes('width="100"height'), 'Whitespace between SVG attributes preserved');
   });
 
   test('`removeAttributeQuotes` applies inside SVG when `minifySVG` is disabled', async () => {


### PR DESCRIPTION
Resolves #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve meaningful attribute whitespace: spaces in regexes, pre-filled form values, visible labels/placeholders, and inside event-handler string literals are no longer collapsed.

* **Documentation**
  * Updated acknowledgements to include an additional contributor and broadened wording.

* **Chores**
  * Bumped package version to 6.2.1 and added corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->