### PR TITLE
Prevent large input cache key collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.2] - 2026-05-02
+
+### Fixed
+
+* Fixed a cache key collision for large CSS, JS, and SVG inputs (>2,048 characters):
+  - The previous fingerprint scheme (length + first/last 50 characters) could return incorrect cached minification results when two inputs shared the same length and the same first and last 50 characters
+  - Keys for large inputs now use an FNV-1a hash of the full content
+
 ## [6.2.1] - 2026-05-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.1"
+  "version": "6.2.2"
 }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -131,10 +131,9 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           );
         }
 
-        // Cache key: Wrapped content, type, options signature
+        // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys
         const inputCSS = wrapCSS(text, type);
         const cssSig = stableStringify({ type, opts: lightningCssOptions, cont: !!options.continueOnMinifyError });
-        // For large inputs, use length and content fingerprint (first/last 50 chars) to prevent collisions
         const cssKey = inputCSS.length > 2048
           ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
           : (inputCSS + '|' + type + '|' + cssSig);
@@ -246,7 +245,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           // Select pre-computed signature based on engine
           const optsSig = useEngine === 'terser' ? terserSig : swcSig;
 
-          // For large inputs, use length and content fingerprint to prevent collisions
+          // For large inputs, hash the full content to avoid storing huge strings as Map keys
           jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
             + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
@@ -359,7 +358,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           return svgContent;
         }
 
-        // Cache key
+        // Cache key: Large inputs are hashed to avoid huge Map keys
         const svgKey = svgContent.length > 2048
           ? (hashContent(svgContent) + '|' + svgSig)
           : (svgContent + '|' + svgSig);

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,7 +1,7 @@
 // Imports
 
 import { createUrlMinifier } from './urls.js';
-import { LRU, stableStringify, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
+import { LRU, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
 import { RE_TRAILING_SEMICOLON } from './constants.js';
 import { canCollapseWhitespace, canTrimWhitespace } from './whitespace.js';
 import { wrapCSS, unwrapCSS } from './content.js';
@@ -136,7 +136,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         const cssSig = stableStringify({ type, opts: lightningCssOptions, cont: !!options.continueOnMinifyError });
         // For large inputs, use length and content fingerprint (first/last 50 chars) to prevent collisions
         const cssKey = inputCSS.length > 2048
-          ? (inputCSS.length + '|' + inputCSS.slice(0, 50) + inputCSS.slice(-50) + '|' + type + '|' + cssSig)
+          ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
           : (inputCSS + '|' + type + '|' + cssSig);
 
         try {
@@ -247,7 +247,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           const optsSig = useEngine === 'terser' ? terserSig : swcSig;
 
           // For large inputs, use length and content fingerprint to prevent collisions
-          jsKey = (code.length > 2048 ? (code.length + '|' + code.slice(0, 50) + code.slice(-50) + '|') : (code + '|'))
+          jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
             + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
           const cached = jsMinifyCache.get(jsKey);
@@ -361,7 +361,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
         // Cache key
         const svgKey = svgContent.length > 2048
-          ? (svgContent.length + '|' + svgContent.slice(0, 50) + svgContent.slice(-50) + '|' + svgSig)
+          ? (hashContent(svgContent) + '|' + svgSig)
           : (svgContent + '|' + svgSig);
 
         try {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,6 +39,17 @@ class LRU {
   delete(key) { this.map.delete(key); }
 }
 
+// FNV-1a 32-bit hash—collision-resistant key for large-input caches
+
+function hashContent(str) {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
 // Unique ID generator
 
 function uniqueId(value) {
@@ -102,6 +113,7 @@ function parseRegExp(value) {
 
 export { stableStringify };
 export { LRU };
+export { hashContent };
 export { uniqueId };
 export { identity };
 export { isThenable };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,7 +39,7 @@ class LRU {
   delete(key) { this.map.delete(key); }
 }
 
-// FNV-1a 32-bit hash—collision-resistant key for large-input caches
+// FNV-1a 32-bit hash for large-input cache keys
 
 function hashContent(str) {
   let hash = 2166136261;

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -917,5 +917,29 @@ describe('CSS and JS', () => {
         delete process.env.HMN_CACHE_CSS;
       }
     });
+
+    test('Large inputs with identical first/last 50 chars are not confused in cache', async () => {
+      // Craft two CSS inputs that share the same length, first 50 chars, and last 50 chars
+      // but differ in the middle—previously the fingerprint key caused a cache collision
+      const first50 = 'div,p,span,section,article,main,header,footer,nav{'; // exactly 50 chars
+      const last50 = '}/*' + 'x'.repeat(45) + '*/'; // exactly 50 chars
+      const filler = '/* ' + 'f'.repeat(1970) + ' */'; // stripped by minifier
+
+      // `color:red; ` and `color:blue;` are both 11 chars—inputs are the same total length
+      const css1 = first50 + 'color:red; ' + filler + last50;
+      const css2 = first50 + 'color:blue;' + filler + last50;
+
+      assert.ok(css1.length > 2048, 'Input must exceed the 2048-char threshold');
+      assert.strictEqual(css1.length, css2.length, 'Inputs must be the same length to guarantee fingerprint collision');
+      assert.strictEqual(css1.slice(0, 50), css2.slice(0, 50), 'First 50 chars must be identical');
+      assert.strictEqual(css1.slice(-50), css2.slice(-50), 'Last 50 chars must be identical');
+
+      const result1 = await minify(`<style>${css1}</style>`, { minifyCSS: true });
+      const result2 = await minify(`<style>${css2}</style>`, { minifyCSS: true });
+
+      assert.notStrictEqual(result1, result2, 'Different large CSS inputs must not share a cache entry');
+      assert.ok(result1.includes('red'), 'First result should contain the correct color');
+      assert.ok(result2.includes('blue') || result2.includes('#00f'), 'Second result should contain the correct color');
+    });
   });
 });

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -233,6 +233,32 @@ describe('CSS and JS', () => {
     await assert.doesNotReject(minify(input, { continueOnMinifyError: false, minifyCSS: true }));
   });
 
+  test('Large CSS inputs with identical first/last 50 chars are not confused in cache', async () => {
+    // Craft two CSS inputs that share the same length, first 50 chars, and last 50 chars
+    // but differ in the middle—previously the fingerprint key caused a cache collision
+    const first50 = 'div,p,span,section,article,main,header,footer,nav{'; // exactly 50 chars
+    const last50 = '}/*' + 'x'.repeat(45) + '*/'; // exactly 50 chars
+    const filler = '/* ' + 'f'.repeat(1970) + ' */'; // stripped by minifier
+    assert.strictEqual(first50.length, 50, '`first50` must be exactly 50 chars');
+    assert.strictEqual(last50.length, 50, '`last50` must be exactly 50 chars');
+
+    // `color:red; ` and `color:blue;` are both 11 chars—inputs are the same total length
+    const css1 = first50 + 'color:red; ' + filler + last50;
+    const css2 = first50 + 'color:blue;' + filler + last50;
+
+    assert.ok(css1.length > 2048, 'Input must exceed the 2048-char threshold');
+    assert.strictEqual(css1.length, css2.length, 'Inputs must be the same length to guarantee fingerprint collision');
+    assert.strictEqual(css1.slice(0, 50), css2.slice(0, 50), 'First 50 chars must be identical');
+    assert.strictEqual(css1.slice(-50), css2.slice(-50), 'Last 50 chars must be identical');
+
+    const result1 = await minify(`<style>${css1}</style>`, { minifyCSS: true });
+    const result2 = await minify(`<style>${css2}</style>`, { minifyCSS: true });
+
+    assert.notStrictEqual(result1, result2, 'Different large CSS inputs must not share a cache entry');
+    assert.ok(result1.includes('red'), 'First result should contain the correct color');
+    assert.ok(result2.includes('blue') || result2.includes('#00f'), 'Second result should contain the correct color');
+  });
+
   // Tests for `minifyJS` configuration options
   test('JS: Basic boolean true', async () => {
     const input = '<script>function myFunction() { let x = 1; return x; }</script>';
@@ -918,28 +944,28 @@ describe('CSS and JS', () => {
       }
     });
 
-    test('Large inputs with identical first/last 50 chars are not confused in cache', async () => {
-      // Craft two CSS inputs that share the same length, first 50 chars, and last 50 chars
-      // but differ in the middle—previously the fingerprint key caused a cache collision
-      const first50 = 'div,p,span,section,article,main,header,footer,nav{'; // exactly 50 chars
-      const last50 = '}/*' + 'x'.repeat(45) + '*/'; // exactly 50 chars
-      const filler = '/* ' + 'f'.repeat(1970) + ' */'; // stripped by minifier
+    test('Large JS inputs with identical first/last 50 chars are not confused in cache', async () => {
+      const first50 = '/*' + 'a'.repeat(46) + '*/'; // exactly 50 chars
+      const last50 = '/*' + 'b'.repeat(46) + '*/'; // exactly 50 chars
+      const filler = '/*' + 'x'.repeat(1970) + '*/'; // stripped by minifier
+      assert.strictEqual(first50.length, 50, '`first50` must be exactly 50 chars');
+      assert.strictEqual(last50.length, 50, '`last50` must be exactly 50 chars');
 
-      // `color:red; ` and `color:blue;` are both 11 chars—inputs are the same total length
-      const css1 = first50 + 'color:red; ' + filler + last50;
-      const css2 = first50 + 'color:blue;' + filler + last50;
+      // Both middles are 7 chars—inputs are the same total length
+      const js1 = first50 + 'a=1111;' + filler + last50;
+      const js2 = first50 + 'a=2222;' + filler + last50;
 
-      assert.ok(css1.length > 2048, 'Input must exceed the 2048-char threshold');
-      assert.strictEqual(css1.length, css2.length, 'Inputs must be the same length to guarantee fingerprint collision');
-      assert.strictEqual(css1.slice(0, 50), css2.slice(0, 50), 'First 50 chars must be identical');
-      assert.strictEqual(css1.slice(-50), css2.slice(-50), 'Last 50 chars must be identical');
+      assert.ok(js1.length > 2048, 'Input must exceed the 2048-char threshold');
+      assert.strictEqual(js1.length, js2.length, 'Inputs must be the same length to guarantee fingerprint collision');
+      assert.strictEqual(js1.slice(0, 50), js2.slice(0, 50), 'First 50 chars must be identical');
+      assert.strictEqual(js1.slice(-50), js2.slice(-50), 'Last 50 chars must be identical');
 
-      const result1 = await minify(`<style>${css1}</style>`, { minifyCSS: true });
-      const result2 = await minify(`<style>${css2}</style>`, { minifyCSS: true });
+      const result1 = await minify(`<script>${js1}</script>`, { minifyJS: true });
+      const result2 = await minify(`<script>${js2}</script>`, { minifyJS: true });
 
-      assert.notStrictEqual(result1, result2, 'Different large CSS inputs must not share a cache entry');
-      assert.ok(result1.includes('red'), 'First result should contain the correct color');
-      assert.ok(result2.includes('blue') || result2.includes('#00f'), 'Second result should contain the correct color');
+      assert.notStrictEqual(result1, result2, 'Different large JS inputs must not share a cache entry');
+      assert.ok(result1.includes('1111'), 'First result should contain the correct value');
+      assert.ok(result2.includes('2222'), 'Second result should contain the correct value');
     });
   });
 });

--- a/tests/svg+mathml.spec.js
+++ b/tests/svg+mathml.spec.js
@@ -377,6 +377,30 @@ describe('SVG and MathML', () => {
     assert.strictEqual(r1, r2, 'Cached result should match first result');
   });
 
+  test('Large SVG inputs with identical first/last 50 chars are not confused in cache', async () => {
+    const first50 = '<svg xmlns="http://www.w3.org/2000/svg" width="10"'; // exactly 50 chars
+    const last50 = '<!-- ' + 'z'.repeat(35) + ' --></svg>'; // exactly 50 chars
+    const filler = '<!-- ' + 'f'.repeat(1970) + ' -->'; // stripped by SVGO
+    assert.strictEqual(first50.length, 50, '`first50` must be exactly 50 chars');
+    assert.strictEqual(last50.length, 50, '`last50` must be exactly 50 chars');
+
+    // Both middles are 34 chars—inputs are the same total length
+    const svg1 = first50 + ' height="10"><rect fill="#f00"/>' + filler + last50;
+    const svg2 = first50 + ' height="10"><rect fill="#0f0"/>' + filler + last50;
+
+    assert.ok(svg1.length > 2048, 'Input must exceed the 2048-char threshold');
+    assert.strictEqual(svg1.length, svg2.length, 'Inputs must be the same length to guarantee fingerprint collision');
+    assert.strictEqual(svg1.slice(0, 50), svg2.slice(0, 50), 'First 50 chars must be identical');
+    assert.strictEqual(svg1.slice(-50), svg2.slice(-50), 'Last 50 chars must be identical');
+
+    const result1 = await minify(svg1, { minifySVG: true });
+    const result2 = await minify(svg2, { minifySVG: true });
+
+    assert.notStrictEqual(result1, result2, 'Different large SVG inputs must not share a cache entry');
+    assert.ok(result1.includes('#f00') || result1.includes('red'), 'First result should contain the correct fill');
+    assert.ok(result2.includes('#0f0') || result2.includes('lime'), 'Second result should contain the correct fill');
+  });
+
   test('SVG and MathML elements should not be removed by `removeEmptyElements`', async () => {
     // SVG elements define their content via attributes (like `d`, `cx`, `r`)
     // They should not be removed as "empty" even without text content


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache key generation for minification of large CSS, JS, and SVG inputs that could previously result in reusing incorrect cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->