### PR TITLE
Remove `continueOnParseError` from comprehensive preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.5] - 2026-05-14
+
+### Changed
+
+* Removed `continueOnParseError` from the `comprehensive` preset, because not related to minification aggressiveness (if needed, the behavior can be opted in explicitly)
+
 ## [6.2.4] - 2026-05-05
 
 ### Fixed
@@ -36,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - `value` on form-submission elements (`input`, `option`, `button`, `data`, `param`) where the value is used verbatim—but not on numeric elements (like `li` or `meter`) where the browser normalizes it
   - `title` (line breaks and spacing render visibly in browser tooltips)
   - `placeholder` (spaces render visibly in inputs)
-  - event handler attributes (spaces inside string literals, e.g., `onclick="alert('→     ←')"`).
+  - event handler attributes (spaces inside string literals, e.g., `onclick="alert('→     ←')"`)
 
 ## [6.2.0] - 2026-04-24
 
@@ -782,7 +788,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Added `continueOnMinifyError` option to control error handling during CSS, JavaScript, and URL minification. When set to `false`, minification errors will throw and may abort processing. When set to `true` (the default), the minifier attempts to recover from errors, preserving the original content when minification fails. This provides users with explicit control over error handling and helps ensure invalid syntax is not silently ignored when strict validation is needed.
+* Added `continueOnMinifyError` option to control error handling during CSS, JavaScript, and URL minification. When set to `false`, minification errors will throw and may abort processing. When set to `true` (the default), the minifier attempts to recover from errors, preserving the original content when minification fails. This provides users with explicit control over error handling and helps ensure invalid syntax is not silently ignored when strict validation is needed
 * Added CLI flag `--no-continue-on-minify-error` to disable error recovery from the command line
 * Added test coverage including error scenarios across CSS, JavaScript, and URL minification
 
@@ -1068,8 +1074,8 @@ If you rely on specific CSS output formatting, review your CSS after upgrading a
 
 ### Changed
 
-* **BREAKING:** Removed `HTMLtoXML` and `HTMLtoDOM` functions from the public API. These XML-related functions were outdated and no longer relevant to the library’s focus on HTML minification.
-* **BREAKING:** Deep imports to internal modules are no longer supported. Use the main export instead of importing from specific source files.
+* **BREAKING:** Removed `HTMLtoXML` and `HTMLtoDOM` functions from the public API; these XML-related functions were outdated and no longer relevant to the library’s focus on HTML minification
+* **BREAKING:** Deep imports to internal modules are no longer supported—use the main export instead of importing from specific source files
 * Updated comment references from “HTML5 elements” to “HTML elements” for accuracy
 * Streamlined codebase by removing unused utility functions
 * Updated package exports to enforce clean API boundaries

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.4",
+      "version": "6.2.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -2365,9 +2365,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5274,9 +5274,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true
     },
     "fdir": {

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.4"
+  "version": "6.2.5"
 }

--- a/src/presets.js
+++ b/src/presets.js
@@ -22,7 +22,6 @@ export const presets = {
     collapseAttributeWhitespace: true,
     collapseBooleanAttributes: true,
     collapseWhitespace: true,
-    continueOnParseError: true,
     decodeEntities: true,
     mergeScripts: true,
     minifyCSS: true,


### PR DESCRIPTION
Resolves #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 6.2.5.
  * Removed `continueOnParseError` option from the `comprehensive` preset.

* **Documentation**
  * Updated changelog with latest release information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j9t/html-minifier-next/pull/277)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->