### PR TITLE
Add CLI alias `hmn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.6] - 2026-05-14
+
+### Added
+
+* Added `hmn` as a short CLI alias for `html-minifier-next` (both commands work identically after a global install)
+
 ## [6.2.5] - 2026-05-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Added `hmn` as a short CLI alias for `html-minifier-next` (both commands work identically after a global install)
+* Added `hmn` as a short CLI alias for `html-minifier-next`
 
 ## [6.2.5] - 2026-05-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.5",
+      "version": "6.2.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -16,6 +16,7 @@
         "terser": "^5.46.2"
       },
       "bin": {
+        "hmn": "cli.js",
         "html-minifier-next": "cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "author": "Jens Oliver Meiert",
   "bin": {
-    "html-minifier-next": "./cli.js"
+    "html-minifier-next": "./cli.js",
+    "hmn": "./cli.js"
   },
   "bugs": "https://github.com/j9t/html-minifier-next/issues",
   "dependencies": {
@@ -96,5 +97,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.5"
+  "version": "6.2.6"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `hmn` as a convenient short alias for the `html-minifier-next` CLI command, making it quicker and easier to invoke the HTML minification tool from the command line.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j9t/html-minifier-next/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->