### PR TITLE
Fix optional tags handling around `htmlmin:ignore` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.7] - 2026-05-22
+
+### Fixed
+
+* Fixed optional end tags (e.g., `</head>`) not being removed when immediately followed by an `htmlmin:ignore` block or an `ignoreCustomFragments` token—both placeholder mechanisms were resetting the optional-tag state before the next element could trigger the removal
+
 ## [6.2.6] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fixed optional end tags (e.g., `</head>`) not being removed when immediately followed by an `htmlmin:ignore` block or an `ignoreCustomFragments` token—both placeholder mechanisms were resetting the optional-tag state before the next element could trigger the removal
+* Fixed optional tags (e.g., `</head>`, `<body>`) not being removed when immediately followed by an `htmlmin:ignore` block or an `ignoreCustomFragments` token
+  - In the `htmlmin:ignore` case the UID placeholder comment was resetting the optional-tag state before the next element could trigger removal
+  - In the `ignoreCustomFragments` case the synthetic tab padding on the replacement token was falsely registering as leading whitespace and suppressing removal
 
 ## [6.2.6] - 2026-05-14
 

--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 /**
  * html-minifier-next CLI tool
  *
- * The MIT License (MIT)
+ * MIT License
  *
  *  Copyright 2014–2016 Zoltan Frombach
  *  Copyright Juriy “kangax” Zaytsev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.6",
+  "version": "6.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.6",
+      "version": "6.2.7",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -1696,10 +1696,11 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -4820,9 +4821,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.6"
+  "version": "6.2.7"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1480,11 +1480,11 @@ async function minifyHTML(value, options, partialMarkup) {
           // UID-attr tokens are padded with `\t`, which would falsely look like leading whitespace;
           // resolve single-token text to its actual content for the space/comment checks below
           let effectiveText = text;
-          if (uidAttrSinglePattern) {
+          if (uidAttrSinglePattern && text.includes(uidAttr)) {
             const uidMatch = uidAttrSinglePattern.exec(text);
             if (uidMatch) {
               const idx = +uidMatch[1];
-              const chunks = idx >= 0 && idx < ignoredCustomMarkupChunks.length ? ignoredCustomMarkupChunks[idx] : null;
+              const chunks = idx < ignoredCustomMarkupChunks.length ? ignoredCustomMarkupChunks[idx] : null;
               if (chunks != null) {
                 effectiveText = chunks[0];
               }
@@ -1564,16 +1564,18 @@ async function minifyHTML(value, options, partialMarkup) {
       // Finalization phase (sync): Optional tag handling, `htmlmin:ignore` whitespace collapsing, buffer push
       function commentFinalize(comment) {
         if (options.removeOptionalTags && comment) {
-          if (uidIgnorePlaceholderPattern && uidIgnorePlaceholderPattern.test(comment)) {
-            // UID placeholders represent real HTML content, not true HTML comments;
-            // if there’s a pending optional end tag and the ignored content isn’t itself
-            // a comment (which per the HTML spec prevents omission), resolve it now,
-            // before the UID is pushed to the buffer
-            const match = comment.match(uidIgnorePlaceholderPattern);
-            const idx = match ? +match[1] : -1;
-            const content = idx >= 0 && idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
-            if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
-              removeEndTag();
+          if (uidIgnorePlaceholderPattern) {
+            const match = uidIgnorePlaceholderPattern.exec(comment);
+            if (match) {
+              // UID placeholders represent real HTML content, not true HTML comments;
+              // if there’s a pending optional end tag and the ignored content isn’t itself
+              // a comment (which per the HTML spec prevents omission), resolve it now,
+              // before the UID is pushed to the buffer
+              const idx = +match[1];
+              const content = idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
+              if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
+                removeEndTag();
+              }
             }
           }
           // Comments (real or placeholder) always suppress optional start tag omissions

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -949,7 +949,7 @@ async function minifyHTML(value, options, partialMarkup) {
   let uidIgnorePlaceholderPattern;
   let uidAttr;
   let uidPattern;
-  let uidAttrSinglePattern;
+  let uidAttrLeadingPattern;
   // Create inline tags/text sets with custom elements
   const customElementsInput = options.inlineCustomElements ?? [];
   const customElementsArr = Array.isArray(customElementsInput) ? customElementsInput : Array.from(customElementsInput);
@@ -1041,7 +1041,7 @@ async function minifyHTML(value, options, partialMarkup) {
       if (!uidAttr) {
         uidAttr = uniqueId(value);
         uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)' + uidAttr + '(\\s*)', 'g');
-        uidAttrSinglePattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr + '\\s*$');
+        uidAttrLeadingPattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr);
 
         if (options.minifyCSS) {
           options.minifyCSS = (function (fn) {
@@ -1480,8 +1480,8 @@ async function minifyHTML(value, options, partialMarkup) {
           // UID-attr tokens are padded with `\t`, which would falsely look like leading whitespace;
           // resolve single-token text to its actual content for the space/comment checks below
           let effectiveText = text;
-          if (uidAttrSinglePattern && text.includes(uidAttr)) {
-            const uidMatch = uidAttrSinglePattern.exec(text);
+          if (uidAttrLeadingPattern && text.includes(uidAttr)) {
+            const uidMatch = uidAttrLeadingPattern.exec(text);
             if (uidMatch) {
               const idx = +uidMatch[1];
               const chunks = idx < ignoredCustomMarkupChunks.length ? ignoredCustomMarkupChunks[idx] : null;

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1574,7 +1574,11 @@ async function minifyHTML(value, options, partialMarkup) {
               const idx = +match[1];
               const content = idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
               if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
-                removeEndTag();
+                const firstTagMatch = content.match(/[^<]*<([a-zA-Z][^\s/>]*)/);
+                const firstTag = firstTagMatch ? options.name(firstTagMatch[1]) : '';
+                if (canRemovePrecedingTag(optionalEndTag, firstTag)) {
+                  removeEndTag();
+                }
               }
             }
           }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -949,6 +949,7 @@ async function minifyHTML(value, options, partialMarkup) {
   let uidIgnorePlaceholderPattern;
   let uidAttr;
   let uidPattern;
+  let uidAttrSinglePattern;
   // Create inline tags/text sets with custom elements
   const customElementsInput = options.inlineCustomElements ?? [];
   const customElementsArr = Array.isArray(customElementsInput) ? customElementsInput : Array.from(customElementsInput);
@@ -1040,6 +1041,7 @@ async function minifyHTML(value, options, partialMarkup) {
       if (!uidAttr) {
         uidAttr = uniqueId(value);
         uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)' + uidAttr + '(\\s*)', 'g');
+        uidAttrSinglePattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr + '\\s*$');
 
         if (options.minifyCSS) {
           options.minifyCSS = (function (fn) {
@@ -1475,15 +1477,28 @@ async function minifyHTML(value, options, partialMarkup) {
       // Finalization phase (sync): Optional tag handling, entity re-encoding, buffer push
       function charsFinalize(text) {
         if (options.removeOptionalTags && text) {
+          // UID-attr tokens are padded with `\t`, which would falsely look like leading whitespace;
+          // resolve single-token text to its actual content for the space/comment checks below
+          let effectiveText = text;
+          if (uidAttrSinglePattern) {
+            const uidMatch = uidAttrSinglePattern.exec(text);
+            if (uidMatch) {
+              const idx = +uidMatch[1];
+              const chunks = idx >= 0 && idx < ignoredCustomMarkupChunks.length ? ignoredCustomMarkupChunks[idx] : null;
+              if (chunks != null) {
+                effectiveText = chunks[0];
+              }
+            }
+          }
           // `<html>` may be omitted if first thing inside is not a comment
           // `<body>` may be omitted if first thing inside is not space, comment, `<meta>`, `<link>`, `<script>`, `<style>`, or `<template>`
-          if (optionalStartTag === 'html' || (optionalStartTag === 'body' && !/^\s/.test(text))) {
+          if (optionalStartTag === 'html' || (optionalStartTag === 'body' && !/^\s/.test(effectiveText))) {
             removeStartTag();
           }
           optionalStartTag = '';
           // `</html>` or `</body>` may be omitted if not followed by comment
           // `</head>`, `</colgroup>`, or `</caption>` may be omitted if not followed by space or comment
-          if (optionalEndTagEmitted && (compactElements.has(optionalEndTag) || (looseElements.has(optionalEndTag) && !/^\s/.test(text)))) {
+          if (optionalEndTagEmitted && (compactElements.has(optionalEndTag) || (looseElements.has(optionalEndTag) && !/^\s/.test(effectiveText)))) {
             removeEndTag();
           }
           // Don’t reset `optionalEndTag` if text is only whitespace and will be collapsed (not conservatively)
@@ -1549,7 +1564,19 @@ async function minifyHTML(value, options, partialMarkup) {
       // Finalization phase (sync): Optional tag handling, `htmlmin:ignore` whitespace collapsing, buffer push
       function commentFinalize(comment) {
         if (options.removeOptionalTags && comment) {
-          // Preceding comments suppress tag omissions
+          if (uidIgnorePlaceholderPattern && uidIgnorePlaceholderPattern.test(comment)) {
+            // UID placeholders represent real HTML content, not true HTML comments;
+            // if there’s a pending optional end tag and the ignored content isn’t itself
+            // a comment (which per the HTML spec prevents omission), resolve it now,
+            // before the UID is pushed to the buffer
+            const match = comment.match(uidIgnorePlaceholderPattern);
+            const idx = match ? +match[1] : -1;
+            const content = idx >= 0 && idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
+            if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
+              removeEndTag();
+            }
+          }
+          // Comments (real or placeholder) always suppress optional start tag omissions
           optionalStartTag = '';
           optionalEndTag = '';
           optionalEndTagEmitted = false;

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1574,7 +1574,7 @@ async function minifyHTML(value, options, partialMarkup) {
               const idx = +match[1];
               const content = idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
               if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
-                const firstTagMatch = content.match(/[^<]*<([a-zA-Z][^\s/>]*)/);
+                const firstTagMatch = content.match(/^\s*<([a-zA-Z][^\s/>]*)/);
                 const firstTag = firstTagMatch ? options.name(firstTagMatch[1]) : '';
                 if (canRemovePrecedingTag(optionalEndTag, firstTag)) {
                   removeEndTag();

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2516,6 +2516,15 @@ describe('HTML', () => {
     input = '<style>body{font-size:<%=1%>2pt}</style>';
     assert.strictEqual(await minify(input), input);
     assert.strictEqual(await minify(input, { minifyCSS: true }), input);
+
+    // Optional end tags before custom fragments should still be removed
+    input = '<head><title>T</title></head><?foo?><body><p>hi</p>';
+    output = '<title>T</title><?foo?><p>hi';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), output);
+
+    input = '<head><title>T</title></head>{{expr}}<body><p>hi</p>';
+    output = '<title>T</title>{{expr}}<p>hi';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
   });
 
   test('`caseSensitive`', async () => {
@@ -3708,6 +3717,15 @@ describe('HTML', () => {
 
     input = '<!-- htmlmin:ignore -->+<!-- htmlmin:ignore -->0';
     assert.strictEqual(await minify(input), '+0');
+
+    // Optional end tags before `htmlmin:ignore` blocks should still be removed
+    input = '<head><title>T</title></head><!-- htmlmin:ignore --><body><!-- htmlmin:ignore --><p>hi</p>';
+    output = '<title>T</title><body><p>hi';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), output);
+
+    input = '<!-- htmlmin:ignore --><head><!-- htmlmin:ignore --><title>T</title></head><!-- htmlmin:ignore --><body><!-- htmlmin:ignore --><p>hi</p>';
+    output = '<head><title>T</title><body><p>hi';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), output);
   });
 
   test('Whitespace-collapse between consecutive `htmlmin:ignore` blocks', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2525,6 +2525,11 @@ describe('HTML', () => {
     input = '<head><title>T</title></head>{{expr}}<body><p>hi</p>';
     output = '<title>T</title>{{expr}}<p>hi';
     assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
+
+    // Multiple separate fragments (whitespace between prevents merging into one token) must not block removal
+    input = '<head><title>T</title></head>{{a}} {{b}}<body><p>hi</p>';
+    output = '<title>T</title>{{a}} {{b}}<p>hi';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
   });
 
   test('`caseSensitive`', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -3726,6 +3726,13 @@ describe('HTML', () => {
     input = '<!-- htmlmin:ignore --><head><!-- htmlmin:ignore --><title>T</title></head><!-- htmlmin:ignore --><body><!-- htmlmin:ignore --><p>hi</p>';
     output = '<head><title>T</title><body><p>hi';
     assert.strictEqual(await minify(input, { removeOptionalTags: true }), output);
+
+    // Optional end tag removal must respect element-specific rules when the following element is in an ignore block
+    input = '<p>text</p><!-- htmlmin:ignore --><span>foo</span><!-- htmlmin:ignore -->';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), '<p>text</p><span>foo</span>');
+
+    input = '<p>text</p><!-- htmlmin:ignore --><div>foo</div><!-- htmlmin:ignore -->';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), '<p>text<div>foo</div>');
   });
 
   test('Whitespace-collapse between consecutive `htmlmin:ignore` blocks', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -3738,6 +3738,10 @@ describe('HTML', () => {
 
     input = '<p>text</p><!-- htmlmin:ignore --><div>foo</div><!-- htmlmin:ignore -->';
     assert.strictEqual(await minify(input, { removeOptionalTags: true }), '<p>text<div>foo</div>');
+
+    // A closing tag at the start of an ignore block must not cause the regex to skip ahead and match a later opening tag
+    input = '<p>text</p><!-- htmlmin:ignore --></div><p>next</p><!-- htmlmin:ignore -->';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true }), '<p>text</p></div><p>next</p>');
   });
 
   test('Whitespace-collapse between consecutive `htmlmin:ignore` blocks', async () => {

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2530,6 +2530,15 @@ describe('HTML', () => {
     input = '<head><title>T</title></head>{{a}} {{b}}<body><p>hi</p>';
     output = '<title>T</title>{{a}} {{b}}<p>hi';
     assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
+
+    // `</colgroup>` and `</caption>` (`looseElements`) before custom fragments should also be removed
+    input = '<table><colgroup><col></colgroup>{{x}}<tr><td>hi</td></tr></table>';
+    output = '<table><col>{{x}}<tr><td>hi</table>';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
+
+    input = '<table><caption>T</caption>{{x}}<col><tr><td>hi</td></tr></table>';
+    output = '<table><caption>T{{x}}<col><tr><td>hi</table>';
+    assert.strictEqual(await minify(input, { removeOptionalTags: true, ignoreCustomFragments: [/\{\{[\s\S]*?\}\}/] }), output);
   });
 
   test('`caseSensitive`', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional end tags that were previously retained when immediately followed by ignore blocks or ignored custom-fragment tokens are now removed correctly.

* **Documentation**
  * Added CHANGELOG entry for v6.2.7.

* **Tests**
  * Added regression tests covering optional end‑tag removal around ignore blocks and custom fragments.

* **Chores**
  * Version bumped to 6.2.7.
  * Updated CLI license header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j9t/html-minifier-next/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->