### PR TITLE
Improve performance by allowing to skip `ignoreCustomFragments` scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.8] - 2026-06-02
+
+### Changed
+
+* Improved minification performance by skipping the `ignoreCustomFragments` scan when the input contains no matching fragments
+  - The fragment-extraction regex is padded with bounded whitespace quantifiers on both sides, which made the engine consume and backtrack at every whitespace run across the whole document—wasted work for the common case of no template fragments
+  - A cheap unpadded probe now precedes the full replace; since the padding is optional and at least one fragment match is required, a probe that finds nothing guarantees the replace is a no-op
+
 ## [6.2.7] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ For CLI usage, using a config file is strongly recommended to avoid complex shel
 \{%[\s\S]{0,1000}?%\} \{\{[\s\S]{0,500}?\}\}
 ```
 
-## Running HTML Minifier Next locally
+## Working on HTML Minifier Next
 
 ### Local server
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.7",
+  "version": "6.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.7",
+      "version": "6.2.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.7"
+  "version": "6.2.8"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1031,47 +1031,55 @@ async function minifyHTML(value, options, partialMarkup) {
     const maxQuantifier = options.customFragmentQuantifierLimit || 200;
     const whitespacePattern = `\\s{0,${maxQuantifier}}`;
 
-    // Use bounded quantifiers to prevent ReDoS—this approach prevents exponential backtracking
-    const reCustomIgnore = new RegExp(
-      whitespacePattern + '(?:' + customFragments.join('|') + '){1,' + maxQuantifier + '}' + whitespacePattern,
-      'g'
-    );
-    // Temporarily replace custom ignored fragments with unique attributes
-    value = value.replace(reCustomIgnore, function (match) {
-      if (!uidAttr) {
-        uidAttr = uniqueId(value);
-        uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)' + uidAttr + '(\\s*)', 'g');
-        uidAttrLeadingPattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr);
+    // Fast path: The padded replace below is costly on large inputs because the
+    // `\s{0,N}` padding makes the regex engine consume and backtrack at every
+    // whitespace run; since the padding is optional and the fragment group requires
+    // at least one match, a single unpadded probe that finds nothing proves the
+    // replace would be a no-op—so skip it entirely
+    const reFragmentProbe = new RegExp('(?:' + customFragments.join('|') + ')');
+    if (reFragmentProbe.test(value)) {
+      // Use bounded quantifiers to prevent ReDoS—this approach prevents exponential backtracking
+      const reCustomIgnore = new RegExp(
+        whitespacePattern + '(?:' + customFragments.join('|') + '){1,' + maxQuantifier + '}' + whitespacePattern,
+        'g'
+      );
+      // Temporarily replace custom ignored fragments with unique attributes
+      value = value.replace(reCustomIgnore, function (match) {
+        if (!uidAttr) {
+          uidAttr = uniqueId(value);
+          uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)' + uidAttr + '(\\s*)', 'g');
+          uidAttrLeadingPattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr);
 
-        if (options.minifyCSS) {
-          options.minifyCSS = (function (fn) {
-            return function (text, type) {
-              text = text.replace(uidPattern, function (match, prefix, index) {
-                const chunks = ignoredCustomMarkupChunks[+index];
-                return chunks[1] + uidAttr + index + uidAttr + chunks[2];
-              });
+          if (options.minifyCSS) {
+            options.minifyCSS = (function (fn) {
+              return function (text, type) {
+                text = text.replace(uidPattern, function (match, prefix, index) {
+                  const chunks = ignoredCustomMarkupChunks[+index];
+                  return chunks[1] + uidAttr + index + uidAttr + chunks[2];
+                });
 
-              return fn(text, type);
-            };
-          })(options.minifyCSS);
+                return fn(text, type);
+              };
+            })(options.minifyCSS);
+          }
+
+          if (options.minifyJS) {
+            options.minifyJS = (function (fn) {
+              return function (text, inline, isModule) {
+                return fn(text.replace(uidPattern, function (match, prefix, index) {
+                  const chunks = ignoredCustomMarkupChunks[+index];
+                  return chunks[1] + uidAttr + index + uidAttr + chunks[2];
+                }), inline, isModule);
+              };
+            })(options.minifyJS);
+          }
         }
 
-        if (options.minifyJS) {
-          options.minifyJS = (function (fn) {
-            return function (text, inline, isModule) {
-              return fn(text.replace(uidPattern, function (match, prefix, index) {
-                const chunks = ignoredCustomMarkupChunks[+index];
-                return chunks[1] + uidAttr + index + uidAttr + chunks[2];
-              }), inline, isModule);
-            };
-          })(options.minifyJS);
-        }
-      }
-
-      const token = uidAttr + ignoredCustomMarkupChunks.length + uidAttr;
-      ignoredCustomMarkupChunks.push(/^(\s*)[\s\S]*?(\s*)$/.exec(match));
-      return '\t' + token + '\t';
-    });
+        const token = uidAttr + ignoredCustomMarkupChunks.length + uidAttr;
+        ignoredCustomMarkupChunks.push(/^(\s*)[\s\S]*?(\s*)$/.exec(match));
+        return '\t' + token + '\t';
+      });
+    }
   }
 
   function canCollapseWhitespace(tag, attrs) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved minification speed: the minifier now skips expensive fragment-extraction processing when the input contains no matching template fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->