### PR TITLE
Enable strict type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.9] - 2026-06-04
+
+### Fixed
+
+* Fixed `isIgnoredComment` silently skipping when `ignoreCustomComments` was a non-array value (falsy length); now guarded explicitly
+* Fixed several latent type issues uncovered by stricter checking
+
+### Changed
+
+* Extended TypeScript strictness
+* Enabled `checkJs: true` and `strict: true` in `tsconfig.json`, making TypeScript type-check all JavaScript source files with strict settings
+
 ## [6.2.8] - 2026-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.9] - 2026-06-05
+## [6.2.9] - 2026-06-06
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.9] - 2026-06-04
+## [6.2.9] - 2026-06-05
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -611,9 +611,17 @@ Parameters:
 * `--iterations=N`: Sets the number of timed iterations (default 5; the median is reported)
 * `--config=PATH`: Uses an alternative options file (default `html-minifier.json`)
 
-#### How to compare branches
+To compare branches (A/B run), execute `npm run benchmark -- --save` on `main`, then `npm run benchmark` on the branch to see the deltas. Add `--core` on both ends when measuring changes to HMN’s own code rather than the bundled minifiers.
 
-A typical A/B run: `npm run benchmark -- --save` on `main`, then `npm run benchmark` on the branch to see the deltas. Add `--core` on both ends when measuring changes to HMN’s own code rather than the bundled minifiers.
+#### Profiling
+
+To profile the current working tree, run the benchmark with Node’s built-in CPU profiler:
+
+```shell
+node --cpu-prof benchmark.js
+```
+
+This writes a `.cpuprofile` file to the working directory. Load it with `npx speedscope *.cpuprofile` for a flamegraph, or drag it into Chrome DevTools → Sources → JavaScript Profiler. Compare self-time per function against a clean baseline run on `main`. Pay attention to unexpectedly heavy callbacks in hot paths—V8 de-optimization from variable object shapes or unnecessary method calls can show up there.
 
 ## Acknowledgements
 

--- a/backtest/backtest.js
+++ b/backtest/backtest.js
@@ -263,7 +263,7 @@ async function minify(hash, options) {
         if (minified != null) {
           process.send({ name: fileName, size: minified.length, time: duration });
         } else {
-          throw new Error('unexpected result: ' + minified);
+          throw new Error('Unexpected result: ' + minified);
         }
       } catch (err) {
         console.error('[' + fileName + ']', err.stack || err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.8",
+  "version": "6.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.8",
+      "version": "6.2.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -26,6 +26,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@swc/core": "^1.15.40",
+        "@types/node": "^25.9.1",
         "eslint": "^10.4.0",
         "rollup": "^4.60.4",
         "rollup-plugin-polyfill-node": "^0.13.0",
@@ -1551,13 +1552,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/resolve": {
@@ -3532,11 +3533,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4585,13 +4586,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "undici-types": "~7.8.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "@types/resolve": {
@@ -5860,11 +5860,10 @@
       "dev": true
     },
     "undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "peer": true
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@swc/core": "^1.15.40",
+    "@types/node": "^25.9.1",
     "eslint": "^10.4.0",
     "rollup": "^4.60.4",
     "rollup-plugin-polyfill-node": "^0.13.0",
@@ -97,5 +98,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.8"
+  "version": "6.2.9"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -726,10 +726,11 @@ function mergeConsecutiveScripts(html) {
 async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupChunks) {
   const attrChains = options.sortAttributes && typeof options.sortAttributes !== 'function' && Object.create(null);
   const classChain = options.sortClassNames && typeof options.sortClassNames !== 'function' && new TokenChain();
+  const resolveName = /** @type {(name: string) => string} */ (options.name);
 
   function attrNames(/** @type {HTMLAttribute[]} */ attrs) {
     return attrs.map(function (attr) {
-      return options.name?.(attr.name) ?? attr.name;
+      return resolveName(attr.name);
     });
   }
 
@@ -766,7 +767,7 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
           attrChains[tag].add(attrNamesList);
         }
         for (const attr of attrs) {
-          if (classChain && attr.value && options.name?.(attr.name) === 'class') {
+          if (classChain && attr.value && resolveName(attr.name) === 'class') {
             const classes = trimWhitespace(attr.value).split(whitespaceSplitPatternScan).filter(shouldKeepToken);
             classChain.add(classes);
           } else if (options.processScripts && attr.name.toLowerCase() === 'type') {
@@ -958,6 +959,10 @@ async function minifyHTML(value, options, partialMarkup) {
     value = collapseWhitespace(value, options, true, true);
   }
 
+  const resolveName = /** @type {(name: string) => string} */ (options.name);
+  /** @type {HTMLAttribute[]} */
+  const emptyAttrs = [];
+
   /** @type {string[]} */
   const buffer = [];
   /** @type {string} */
@@ -993,7 +998,7 @@ async function minifyHTML(value, options, partialMarkup) {
   // Create inline tags/text sets with custom elements
   const customElementsInput = options.inlineCustomElements ?? [];
   const customElementsArr = Array.isArray(customElementsInput) ? customElementsInput : Array.from(customElementsInput);
-  const normalizedCustomElements = customElementsArr.map(name => options.name?.(name) ?? name);
+  const normalizedCustomElements = customElementsArr.map(name => resolveName(name));
   // Fast path: Reuse base sets if no custom elements
   const inlineTextSet = normalizedCustomElements.length
     ? new Set([...inlineElementsToKeepWhitespaceWithin, ...normalizedCustomElements])
@@ -1149,7 +1154,7 @@ async function minifyHTML(value, options, partialMarkup) {
 
   // Look for trailing whitespaces, bypass any inline tags
   function trimTrailingWhitespace(/** @type {number} */ index, /** @type {string} */ nextTag) {
-    for (let endTag = ''; index >= 0 && canTrimWhitespace(endTag, []); index--) {
+    for (let endTag = ''; index >= 0 && canTrimWhitespace(endTag, emptyAttrs); index--) {
       const str = buffer[index] ?? '';
       const match = str.match(/^<\/([\w:-]+)>$/);
       if (match) {
@@ -1378,7 +1383,7 @@ async function minifyHTML(value, options, partialMarkup) {
         let preserve = false;
         if (removeEmptyElementsExcept.length) {
           // Normalize attribute names for comparison with specs
-          const normalizedAttrs = attrs.map((/** @type {HTMLAttribute} */ attr) => ({ ...attr, name: options.name?.(attr.name) ?? attr.name }));
+          const normalizedAttrs = attrs.map((/** @type {HTMLAttribute} */ attr) => ({ ...attr, name: resolveName(attr.name) }));
           preserve = shouldPreserveEmptyElement(tag, normalizedAttrs, removeEmptyElementsExcept);
         }
 
@@ -1489,7 +1494,7 @@ async function minifyHTML(value, options, partialMarkup) {
                     if (lastTagMatch) {
                       const group = lastTagMatch[1] ?? '';
                       const isClose = group.charAt(0) === '/';
-                      const tagName = options.name?.(isClose ? group.slice(1) : group) ?? group;
+                      const tagName = resolveName(isClose ? group.slice(1) : group);
                       effectivePrevTag = isClose ? '/' + tagName : tagName;
                     }
                   }
@@ -1627,7 +1632,7 @@ async function minifyHTML(value, options, partialMarkup) {
               if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
                 const firstTagMatch = content.match(/^\s*<([a-zA-Z][^\s/>]*)/);
                 const firstTagGroup = firstTagMatch?.[1] ?? '';
-                const firstTag = firstTagGroup ? (options.name?.(firstTagGroup) ?? firstTagGroup) : '';
+                const firstTag = firstTagGroup ? resolveName(firstTagGroup) : '';
                 if (canRemovePrecedingTag(optionalEndTag, firstTag)) {
                   removeEndTag();
                 }
@@ -1679,10 +1684,10 @@ async function minifyHTML(value, options, partialMarkup) {
                       // Collapse if both sides are element/closing tags or HTML comments, and neither is inline
                       if ((currentTagMatch || currentIsHtmlComment || currentClosingTagMatch) &&
                           (prevTagMatch || prevIsHtmlComment || prevClosingTagMatch)) {
-                        const currentTag = currentTagMatch ? (options.name?.(currentTagMatch[1] ?? '') ?? currentTagMatch[1] ?? '')
-                          : currentClosingTagMatch ? (options.name?.(currentClosingTagMatch[1] ?? '') ?? currentClosingTagMatch[1] ?? '') : null;
-                        const prevTag = prevTagMatch ? (options.name?.(prevTagMatch[1] ?? '') ?? prevTagMatch[1] ?? '')
-                          : prevClosingTagMatch ? (options.name?.(prevClosingTagMatch[1] ?? '') ?? prevClosingTagMatch[1] ?? '') : null;
+                        const currentTag = currentTagMatch ? resolveName(currentTagMatch[1] ?? '')
+                          : currentClosingTagMatch ? resolveName(currentClosingTagMatch[1] ?? '') : null;
+                        const prevTag = prevTagMatch ? resolveName(prevTagMatch[1] ?? '')
+                          : prevClosingTagMatch ? resolveName(prevClosingTagMatch[1] ?? '') : null;
 
                         // Don’t collapse between inline elements (HTML comments count as non-inline)
                         if (!inlineElements.has(currentTag) && !inlineElements.has(prevTag)) {

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -58,6 +58,7 @@ import { processOptions } from './lib/options.js';
 
 // Lazy-load heavy dependencies only when needed
 
+/** @type {Promise<Function> | undefined} */
 let lightningCSSPromise;
 async function getLightningCSS() {
   if (!lightningCSSPromise) {
@@ -66,6 +67,7 @@ async function getLightningCSS() {
   return lightningCSSPromise;
 }
 
+/** @type {Promise<Function> | undefined} */
 let terserPromise;
 async function getTerser() {
   if (!terserPromise) {
@@ -74,6 +76,7 @@ async function getTerser() {
   return terserPromise;
 }
 
+/** @type {Promise<any> | undefined} */
 let swcPromise;
 async function getSwc() {
   if (!swcPromise) {
@@ -89,6 +92,7 @@ async function getSwc() {
   return swcPromise;
 }
 
+/** @type {Promise<Function> | undefined} */
 let svgoPromise;
 async function getSvgo() {
   if (!svgoPromise) {
@@ -97,6 +101,7 @@ async function getSvgo() {
   return svgoPromise;
 }
 
+/** @type {Promise<Function> | undefined} */
 let decodeHTMLPromise;
 async function getDecodeHTML() {
   if (!decodeHTMLPromise) {
@@ -106,8 +111,11 @@ async function getDecodeHTML() {
 }
 
 // Minification caches (initialized on first use with configurable sizes)
+/** @type {LRU | null} */
 let cssMinifyCache = null;
+/** @type {LRU | null} */
 let jsMinifyCache = null;
+/** @type {LRU | null} */
 let svgMinifyCache = null;
 
 // Pre-compiled patterns for script merging (avoid repeated allocation in hot path)
@@ -169,12 +177,13 @@ function findTagEnd(html, pos) {
  */
 function mergeConsecutiveScripts(html) {
   // Parse an attribute string into a name→value map
-  const parseAttrs = (attrStr) => {
+  const parseAttrs = (/** @type {string} */ attrStr) => {
+    /** @type {Record<string, string>} */
     const attrs = {};
     RE_SCRIPT_ATTRS.lastIndex = 0;
     let m;
     while ((m = RE_SCRIPT_ATTRS.exec(attrStr)) !== null) {
-      const name = m[1].toLowerCase();
+      const name = (m[1] ?? '').toLowerCase();
       const value = m[2] ?? m[3] ?? m[4] ?? '';
       attrs[name] = value;
     }
@@ -208,7 +217,7 @@ function mergeConsecutiveScripts(html) {
       // Skip optional whitespace and check for a consecutive <script> tag
       let i = afterClose1;
       while (i < html.length && (html[i] === ' ' || html[i] === '\t' || html[i] === '\n' || html[i] === '\r' || html[i] === '\f')) i++;
-      if (html.slice(i, i + 7).toLowerCase() !== '<script' || (html[i + 7] !== '>' && !/\s/.test(html[i + 7]))) {
+      if (html.slice(i, i + 7).toLowerCase() !== '<script' || (html.charAt(i + 7) !== '>' && !/\s/.test(html.charAt(i + 7)))) {
         RE_SCRIPT_OPEN.lastIndex = afterClose1;
         continue;
       }
@@ -700,23 +709,35 @@ function mergeConsecutiveScripts(html) {
  *  See also: https://perfectionkills.com/experimenting-with-html-minifier/#use_short_doctype
  *
  *  Default: `false`
+ *
+ * @prop {boolean} [insideSVG] - Internal: Set when inside SVG/MathML context
+ * @prop {boolean} [insideForeignContent] - Internal: Set when inside SVG `foreignObject`
+ * @prop {Function} [parentName] - Internal: Preserved name function during namespace transitions
+ * @prop {Function} [htmlName] - Internal: HTML name function preserved from outer context
  */
 
+/**
+ * @param {string} value
+ * @param {MinifierOptions} options
+ * @param {string} uidIgnore
+ * @param {string} uidAttr
+ * @param {string[]} ignoredMarkupChunks
+ */
 async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupChunks) {
   const attrChains = options.sortAttributes && typeof options.sortAttributes !== 'function' && Object.create(null);
   const classChain = options.sortClassNames && typeof options.sortClassNames !== 'function' && new TokenChain();
 
-  function attrNames(attrs) {
+  function attrNames(/** @type {HTMLAttribute[]} */ attrs) {
     return attrs.map(function (attr) {
-      return options.name(attr.name);
+      return options.name?.(attr.name) ?? attr.name;
     });
   }
 
-  function shouldSkipUID(token, uid) {
+  function shouldSkipUID(/** @type {string} */ token, /** @type {string} */ uid) {
     return !uid || token.indexOf(uid) === -1;
   }
 
-  function shouldKeepToken(token) {
+  function shouldKeepToken(/** @type {string} */ token) {
     // Filter out any HTML comment tokens (UID placeholders)
     // These are temporary markers created by `htmlmin:ignore` and `ignoreCustomFragments`
     if (token.startsWith('<!--') && token.endsWith('-->')) {
@@ -730,10 +751,13 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
   const whitespaceSplitPatternScan = /[ \t\n\f\r]+/;
   const whitespaceSplitPatternSort = /[ \n\f\r]+/;
 
-  async function scan(input) {
-    let currentTag, currentType;
+  async function scan(/** @type {string} */ input) {
+    /** @type {string} */
+    let currentTag;
+    /** @type {string | undefined} */
+    let currentType;
     const parser = new HTMLParser(input, {
-      start: function (tag, attrs) {
+      start: function (/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs) {
         if (attrChains) {
           if (!attrChains[tag]) {
             attrChains[tag] = new TokenChain();
@@ -741,9 +765,8 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
           const attrNamesList = attrNames(attrs).filter(shouldKeepToken);
           attrChains[tag].add(attrNamesList);
         }
-        for (let i = 0, len = attrs.length; i < len; i++) {
-          const attr = attrs[i];
-          if (classChain && attr.value && options.name(attr.name) === 'class') {
+        for (const attr of attrs) {
+          if (classChain && attr.value && options.name?.(attr.name) === 'class') {
             const classes = trimWhitespace(attr.value).split(whitespaceSplitPatternScan).filter(shouldKeepToken);
             classChain.add(classes);
           } else if (options.processScripts && attr.name.toLowerCase() === 'type') {
@@ -755,11 +778,11 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
       end: function () {
         currentTag = '';
       },
-      chars: async function (text) {
+      chars: async function (/** @type {string} */ text) {
         // Only recursively scan HTML content, not JSON-LD or other non-HTML script types
         // `scan()` is for analyzing HTML attribute order, not for parsing JSON
         if (options.processScripts && specialContentElements.has(currentTag) &&
-            options.processScripts.indexOf(currentType) > -1 &&
+            options.processScripts.indexOf(currentType ?? '') > -1 &&
             currentType === 'text/html') {
           await scan(text);
         }
@@ -818,7 +841,7 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
     // Expand UID tokens back to the original content for frequency analysis
     let expandedValue = value;
     if (uidReplacePattern) {
-      expandedValue = value.replace(uidReplacePattern, function (match, index) {
+      expandedValue = value.replace(uidReplacePattern, function (/** @type {string} */ _match, /** @type {string} */ index) {
         return ignoredMarkupChunks[+index] || '';
       });
       // Reset `lastIndex` for pattern reuse
@@ -839,7 +862,11 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
     await scan(scanValue);
   } finally {
     // Restore original option
-    options.continueOnParseError = originalContinueOnParseError;
+    if (originalContinueOnParseError !== undefined) {
+      options.continueOnParseError = originalContinueOnParseError;
+    } else {
+      delete options.continueOnParseError;
+    }
   }
   if (attrChains) {
     const attrSorters = Object.create(null);
@@ -849,14 +876,14 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
     // Memoize sorted attribute orders—attribute sets often repeat in templates
     const attrOrderCache = new LRU(500);
 
-    options.sortAttributes = function (tag, attrs) {
+    options.sortAttributes = function (/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs) {
       const sorter = attrSorters[tag];
       if (sorter) {
         const names = attrNames(attrs);
 
         // Create order-independent cache key from tag and sorted attribute names
         const cacheKey = tag + ':' + names.slice().sort().join(',');
-        let sortedNames = attrOrderCache.get(cacheKey);
+        let sortedNames = /** @type {string[] | undefined} */ (attrOrderCache.get(cacheKey));
 
         if (sortedNames === undefined) {
           // Only sort if not in cache—need to clone names since sort mutates in place
@@ -866,10 +893,10 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
 
         // Apply the sorted order to `attrs`
         const attrMap = Object.create(null);
-        names.forEach(function (name, index) {
+        names.forEach(function (/** @type {string} */ name, /** @type {number} */ index) {
           (attrMap[name] || (attrMap[name] = [])).push(attrs[index]);
         });
-        sortedNames.forEach(function (name, index) {
+        /** @type {string[]} */ (sortedNames).forEach(function (/** @type {string} */ name, /** @type {number} */ index) {
           attrs[index] = attrMap[name].shift();
         });
       }
@@ -880,14 +907,14 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
     // Memoize `sortClassNames` results—class lists often repeat in templates
     const classNameCache = new LRU(500);
 
-    options.sortClassNames = function (value) {
+    options.sortClassNames = function (/** @type {string} */ value) {
       // Fast path: Single class (no spaces) needs no sorting
       if (value.indexOf(' ') === -1) {
         return value;
       }
 
       // Check cache first
-      const cached = classNameCache.get(value);
+      const cached = /** @type {string | undefined} */ (classNameCache.get(value));
       if (cached !== undefined) {
         return cached;
       }
@@ -896,13 +923,13 @@ async function createSortFns(value, options, uidIgnore, uidAttr, ignoredMarkupCh
       // Fast path: Skip if no HTML comments (UID markers) present
       let expandedValue = value;
       if (uidReplacePattern && value.indexOf('<!--') !== -1) {
-        expandedValue = value.replace(uidReplacePattern, function (match, index) {
+        expandedValue = value.replace(uidReplacePattern, function (/** @type {string} */ _match, /** @type {string} */ index) {
           return ignoredMarkupChunks[+index] || '';
         });
         // Reset `lastIndex` for pattern reuse
         uidReplacePattern.lastIndex = 0;
       }
-      const classes = expandedValue.split(whitespaceSplitPatternSort).filter(function(cls) {
+      const classes = expandedValue.split(whitespaceSplitPatternSort).filter(function(/** @type {string} */ cls) {
         return cls !== '';
       });
       const sorted = sorter.sort(classes);
@@ -931,29 +958,42 @@ async function minifyHTML(value, options, partialMarkup) {
     value = collapseWhitespace(value, options, true, true);
   }
 
+  /** @type {string[]} */
   const buffer = [];
-  let charsPrevTag;
+  /** @type {string} */
+  let charsPrevTag = '';
   let currentChars = '';
-  let hasChars;
+  /** @type {boolean} */
+  let hasChars = false;
   let currentTag = '';
+  /** @type {Array<{name: string, value?: string, quote?: string, customAssign?: string, customOpen?: string, customClose?: string}>} */
   let currentAttrs = [];
+  /** @type {string[]} */
   const stackNoTrimWhitespace = [];
+  /** @type {string[]} */
   const stackNoCollapseWhitespace = [];
   let preTextareaDepth = 0; // Count of `pre`/`textarea` entries in `stackNoTrimWhitespace`
   let optionalStartTag = '';
   let optionalEndTag = '';
   let optionalEndTagEmitted = false;
+  /** @type {string[]} */
   const ignoredMarkupChunks = [];
+  /** @type {Array<RegExpExecArray | null>} */
   const ignoredCustomMarkupChunks = [];
+  /** @type {string | undefined} */
   let uidIgnore;
+  /** @type {RegExp | undefined} */
   let uidIgnorePlaceholderPattern;
+  /** @type {string | undefined} */
   let uidAttr;
+  /** @type {RegExp | undefined} */
   let uidPattern;
+  /** @type {RegExp | undefined} */
   let uidAttrLeadingPattern;
   // Create inline tags/text sets with custom elements
   const customElementsInput = options.inlineCustomElements ?? [];
   const customElementsArr = Array.isArray(customElementsInput) ? customElementsInput : Array.from(customElementsInput);
-  const normalizedCustomElements = customElementsArr.map(name => options.name(name));
+  const normalizedCustomElements = customElementsArr.map(name => options.name?.(name) ?? name);
   // Fast path: Reuse base sets if no custom elements
   const inlineTextSet = normalizedCustomElements.length
     ? new Set([...inlineElementsToKeepWhitespaceWithin, ...normalizedCustomElements])
@@ -963,6 +1003,7 @@ async function minifyHTML(value, options, partialMarkup) {
     : inlineElementsToKeepWhitespaceAround;
 
   // Parse `removeEmptyElementsExcept` option
+  /** @type {Array<{tag: string, attrs: {[x: string]: string | undefined} | null}>} */
   let removeEmptyElementsExcept;
   if (options.removeEmptyElementsExcept && !Array.isArray(options.removeEmptyElementsExcept)) {
     if (options.log) {
@@ -970,7 +1011,7 @@ async function minifyHTML(value, options, partialMarkup) {
     }
     removeEmptyElementsExcept = [];
   } else {
-    removeEmptyElementsExcept = parseRemoveEmptyElementsExcept(options.removeEmptyElementsExcept, options) || [];
+    removeEmptyElementsExcept = parseRemoveEmptyElementsExcept(options.removeEmptyElementsExcept || [], /** @type {any} */ (options)) || [];
   }
 
   // Temporarily replace ignored chunks with comments, so that there’s no need to worry what’s there;
@@ -1012,17 +1053,17 @@ async function minifyHTML(value, options, partialMarkup) {
   // This allows proper frequency analysis with access to ignored content via UID tokens
   if ((options.sortAttributes && typeof options.sortAttributes !== 'function') ||
       (options.sortClassNames && typeof options.sortClassNames !== 'function')) {
-    await createSortFns(value, options, uidIgnore, null, ignoredMarkupChunks);
+    await createSortFns(value, options, uidIgnore ?? '', uidAttr ?? '', ignoredMarkupChunks);
   }
 
-  const customFragments = options.ignoreCustomFragments.map(function (re) {
+  const customFragments = (options.ignoreCustomFragments || []).map(function (/** @type {RegExp} */ re) {
     return re.source;
   });
   if (customFragments.length) {
     // Warn about potential ReDoS if custom fragments use unlimited quantifiers
-    for (let i = 0; i < customFragments.length; i++) {
-      if (/[*+]/.test(customFragments[i])) {
-        options.log('Warning: Custom fragment contains unlimited quantifiers (“*” or “+”) which may cause ReDoS vulnerability');
+    for (const fragment of customFragments) {
+      if (/[*+]/.test(fragment)) {
+        options.log?.('Warning: Custom fragment contains unlimited quantifiers (“*” or “+”) which may cause ReDoS vulnerability');
         break;
       }
     }
@@ -1050,28 +1091,28 @@ async function minifyHTML(value, options, partialMarkup) {
           uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)' + uidAttr + '(\\s*)', 'g');
           uidAttrLeadingPattern = new RegExp('^\\s*' + uidAttr + '(\\d+)' + uidAttr);
 
-          if (options.minifyCSS) {
-            options.minifyCSS = (function (fn) {
-              return function (text, type) {
-                text = text.replace(uidPattern, function (match, prefix, index) {
+          if (options.minifyCSS !== identity) {
+            /** @type {any} */ (options).minifyCSS = (function (/** @type {Function} */ fn) {
+              return function (/** @type {string} */ text, /** @type {string} */ type) {
+                text = text.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ _match, /** @type {string} */ _prefix, /** @type {string} */ index) {
                   const chunks = ignoredCustomMarkupChunks[+index];
-                  return chunks[1] + uidAttr + index + uidAttr + chunks[2];
+                  return (chunks?.[1] ?? '') + uidAttr + index + uidAttr + (chunks?.[2] ?? '');
                 });
 
                 return fn(text, type);
               };
-            })(options.minifyCSS);
+            })(/** @type {Function} */ (options.minifyCSS));
           }
 
-          if (options.minifyJS) {
-            options.minifyJS = (function (fn) {
-              return function (text, inline, isModule) {
-                return fn(text.replace(uidPattern, function (match, prefix, index) {
+          if (options.minifyJS !== identity) {
+            options.minifyJS = (function (/** @type {Function} */ fn) {
+              return function (/** @type {string} */ text, /** @type {boolean} */ inline, /** @type {boolean} */ isModule) {
+                return fn(text.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ _match, /** @type {string} */ _prefix, /** @type {string} */ index) {
                   const chunks = ignoredCustomMarkupChunks[+index];
-                  return chunks[1] + uidAttr + index + uidAttr + chunks[2];
+                  return (chunks?.[1] ?? '') + uidAttr + index + uidAttr + (chunks?.[2] ?? '');
                 }), inline, isModule);
               };
-            })(options.minifyJS);
+            })(/** @type {Function} */ (options.minifyJS));
           }
         }
 
@@ -1082,17 +1123,17 @@ async function minifyHTML(value, options, partialMarkup) {
     }
   }
 
-  function canCollapseWhitespace(tag, attrs) {
-    return options.canCollapseWhitespace(tag, attrs, defaultCanCollapseWhitespace);
+  function canCollapseWhitespace(/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs) {
+    return /** @type {Function} */ (options.canCollapseWhitespace)(tag, attrs, defaultCanCollapseWhitespace);
   }
 
-  function canTrimWhitespace(tag, attrs) {
-    return options.canTrimWhitespace(tag, attrs, defaultCanTrimWhitespace);
+  function canTrimWhitespace(/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs) {
+    return /** @type {Function} */ (options.canTrimWhitespace)(tag, attrs, defaultCanTrimWhitespace);
   }
 
   function removeStartTag() {
     let index = buffer.length - 1;
-    while (index > 0 && !RE_START_TAG.test(buffer[index])) {
+    while (index > 0 && !RE_START_TAG.test(buffer[index] ?? '')) {
       index--;
     }
     buffer.length = Math.max(0, index);
@@ -1100,20 +1141,20 @@ async function minifyHTML(value, options, partialMarkup) {
 
   function removeEndTag() {
     let index = buffer.length - 1;
-    while (index > 0 && !RE_END_TAG.test(buffer[index])) {
+    while (index > 0 && !RE_END_TAG.test(buffer[index] ?? '')) {
       index--;
     }
     buffer.length = Math.max(0, index);
   }
 
   // Look for trailing whitespaces, bypass any inline tags
-  function trimTrailingWhitespace(index, nextTag) {
-    for (let endTag = null; index >= 0 && canTrimWhitespace(endTag); index--) {
-      const str = buffer[index];
+  function trimTrailingWhitespace(/** @type {number} */ index, /** @type {string} */ nextTag) {
+    for (let endTag = ''; index >= 0 && canTrimWhitespace(endTag, []); index--) {
+      const str = buffer[index] ?? '';
       const match = str.match(/^<\/([\w:-]+)>$/);
       if (match) {
-        endTag = match[1];
-      } else if (/>$/.test(str) || (buffer[index] = collapseWhitespaceSmart(str, null, nextTag, [], [], options, inlineElements, inlineTextSet))) {
+        endTag = match[1] ?? '';
+      } else if (/>$/.test(str) || (buffer[index] = collapseWhitespaceSmart(str, '', nextTag, [], [], options, inlineElements, inlineTextSet))) {
         break;
       }
     }
@@ -1122,10 +1163,10 @@ async function minifyHTML(value, options, partialMarkup) {
   // Look for trailing whitespaces from previously processed text
   // which may not be trimmed due to a following comment or an empty
   // element which has now been removed
-  function squashTrailingWhitespace(nextTag) {
+  function squashTrailingWhitespace(/** @type {string} */ nextTag) {
     let charsIndex = buffer.length - 1;
     if (buffer.length > 1) {
-      const item = buffer[buffer.length - 1];
+      const item = buffer[buffer.length - 1] ?? '';
       if (/^(?:<!|$)/.test(item) && (!uidIgnore || item.indexOf(uidIgnore) === -1)) {
         charsIndex--;
       }
@@ -1134,6 +1175,7 @@ async function minifyHTML(value, options, partialMarkup) {
   }
 
   // SVG subtree capture: When SVGO is active, record buffer positions for post-processing
+  /** @type {Array<{start: number, end: number}>} */
   const svgBlocks = []; // Array of { start, end } buffer indices
   let svgBufferStartIndex = -1;
   let svgDepth = 0;
@@ -1146,7 +1188,7 @@ async function minifyHTML(value, options, partialMarkup) {
     // Compute `nextTag` only when whitespace collapse features require it
     wantsNextTag: !!(options.collapseWhitespace || options.collapseInlineTagWhitespace || options.conservativeCollapse),
 
-    start: async function (tag, attrs, unary, unarySlash, autoGenerated) {
+    start: async function (/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs, /** @type {boolean} */ unary, /** @type {string} */ unarySlash, /** @type {boolean} */ autoGenerated) {
       const lowerTag = tag.toLowerCase();
       if (lowerTag === 'svg' || lowerTag === 'math') {
         options = Object.create(options);
@@ -1168,21 +1210,21 @@ async function minifyHTML(value, options, partialMarkup) {
       // Note: The element itself is in SVG/MathML namespace, only its children are HTML
       let useParentNameForTag = false;
       if (options.insideForeignContent && (lowerTag === 'foreignobject' ||
-          (lowerTag === 'annotation-xml' && attrs.some(a => a.name.toLowerCase() === 'encoding' &&
-            RE_HTML_ENCODING.test(a.value))))) {
-        const parentName = options.name;
+          (lowerTag === 'annotation-xml' && attrs.some((/** @type {HTMLAttribute} */ a) => a.name.toLowerCase() === 'encoding' &&
+            RE_HTML_ENCODING.test(a.value ?? ''))))) {
+        const parentName = /** @type {(name: string) => string} */ (options.name);
         options = Object.create(options);
         options.caseSensitive = false;
         options.keepClosingSlash = false;
         options.parentName = parentName; // Preserve for the element tag itself
-        options.name = options.htmlName || lowercase;
+        options.name = /** @type {(name: string) => string} */ (options.htmlName ?? lowercase);
         options.insideForeignContent = false;
         // Note: `removeAttributeQuotes`, `removeTagWhitespace`, and `decodeEntities`
         // stay disabled (inherited from SVG context) because the entire SVG block
         // must be valid XML for SVGO processing
         useParentNameForTag = true;
       }
-      tag = (useParentNameForTag ? options.parentName : options.name)(tag);
+      tag = /** @type {(name: string) => string} */ (useParentNameForTag ? options.parentName : options.name)(tag);
       currentTag = tag;
       charsPrevTag = tag;
       if (!inlineTextSet.has(tag)) {
@@ -1248,10 +1290,10 @@ async function minifyHTML(value, options, partialMarkup) {
       // Remove duplicate attributes (per HTML spec, first occurrence wins)
       // Duplicate attributes result in invalid HTML
       // https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
-      deduplicateAttributes(attrs, options.caseSensitive);
+      deduplicateAttributes(attrs, Boolean(options.caseSensitive));
 
       if (options.sortAttributes) {
-        options.sortAttributes(tag, attrs);
+        /** @type {Function} */ (options.sortAttributes)(tag, attrs);
       }
 
       const attrResults = attrs.map(attr => normalizeAttr(attr, attrs, tag, options, minifyHTML));
@@ -1281,7 +1323,7 @@ async function minifyHTML(value, options, partialMarkup) {
         currentTag = '';
       }
     },
-    end: function (tag, attrs, autoGenerated) {
+    end: function (/** @type {string} */ tag, /** @type {HTMLAttribute[]} */ attrs, /** @type {boolean} */ autoGenerated) {
       const lowerTag = tag.toLowerCase();
       // Restore parent context when exiting SVG/MathML or HTML-in-foreign-content elements
       if (lowerTag === 'svg' || lowerTag === 'math') {
@@ -1290,7 +1332,7 @@ async function minifyHTML(value, options, partialMarkup) {
                  !options.insideForeignContent && Object.getPrototypeOf(options).insideForeignContent) {
         options = Object.getPrototypeOf(options);
       }
-      tag = options.name(tag);
+      tag = /** @type {Function} */ (options.name)(tag);
 
       // Check if current tag is in a whitespace stack
       if (options.collapseWhitespace) {
@@ -1336,7 +1378,7 @@ async function minifyHTML(value, options, partialMarkup) {
         let preserve = false;
         if (removeEmptyElementsExcept.length) {
           // Normalize attribute names for comparison with specs
-          const normalizedAttrs = attrs.map(attr => ({ ...attr, name: options.name(attr.name) }));
+          const normalizedAttrs = attrs.map((/** @type {HTMLAttribute} */ attr) => ({ ...attr, name: options.name?.(attr.name) ?? attr.name }));
           preserve = shouldPreserveEmptyElement(tag, normalizedAttrs, removeEmptyElementsExcept);
         }
 
@@ -1383,7 +1425,7 @@ async function minifyHTML(value, options, partialMarkup) {
         }
       }
     },
-    chars: function (text, prevTag, nextTag, prevAttrs, nextAttrs) {
+    chars: function (/** @type {string} */ text, /** @type {string} */ prevTag, /** @type {string} */ nextTag, /** @type {HTMLAttribute[]} */ prevAttrs, /** @type {HTMLAttribute[]} */ nextAttrs) {
       prevTag = prevTag === '' ? 'comment' : prevTag;
       nextTag = nextTag === '' ? 'comment' : nextTag;
       prevAttrs = prevAttrs || [];
@@ -1399,7 +1441,7 @@ async function minifyHTML(value, options, partialMarkup) {
       const needsMinifyCSS = options.minifyCSS !== identity && isStyleElement(currentTag, currentAttrs);
 
       // Whitespace collapsing phase (sync); captures `prevTag`/`nextTag`/`prevAttrs`/`nextAttrs` from outer scope
-      function charsCollapse(text) {
+      function charsCollapse(/** @type {string} */ text) {
         // Trim outermost newline-based whitespace inside `pre`/`textarea` elements
         // This removes trailing newlines often added by template engines before closing tags
         // Only trims single trailing newlines (multiple newlines are likely intentional formatting)
@@ -1421,7 +1463,7 @@ async function minifyHTML(value, options, partialMarkup) {
             // to avoid side effects on the `inlineTextSet` branch below
             let effectivePrevTag = prevTag;
             if (prevTag === 'comment') {
-              const prevComment = buffer[buffer.length - 1];
+              const prevComment = buffer[buffer.length - 1] ?? '';
               if (!uidIgnore || prevComment.indexOf(uidIgnore) === -1) {
                 if (!prevComment) {
                   prevTag = charsPrevTag;
@@ -1429,7 +1471,7 @@ async function minifyHTML(value, options, partialMarkup) {
                 }
                 if (buffer.length > 1 && (!prevComment || (!options.conservativeCollapse && / $/.test(currentChars)))) {
                   const charsIndex = buffer.length - 2;
-                  buffer[charsIndex] = buffer[charsIndex].replace(/\s+$/, function (trailingSpaces) {
+                  buffer[charsIndex] = (buffer[charsIndex] ?? '').replace(/\s+$/, function (trailingSpaces) {
                     text = trailingSpaces + text;
                     return '';
                   });
@@ -1440,13 +1482,14 @@ async function minifyHTML(value, options, partialMarkup) {
                 // when `nextTag` is `comment` (another UID placeholder), `commentFinalize` handles it
                 const match = prevComment.match(uidIgnorePlaceholderPattern);
                 if (match) {
-                  const idx = +match[1];
+                  const idx = +(match[1] ?? '');
                   if (idx < ignoredMarkupChunks.length) {
                     const content = ignoredMarkupChunks[idx];
                     const lastTagMatch = content && RE_LAST_HTML_TAG.exec(content);
                     if (lastTagMatch) {
-                      const isClose = lastTagMatch[1].charAt(0) === '/';
-                      const tagName = options.name(isClose ? lastTagMatch[1].slice(1) : lastTagMatch[1]);
+                      const group = lastTagMatch[1] ?? '';
+                      const isClose = group.charAt(0) === '/';
+                      const tagName = options.name?.(isClose ? group.slice(1) : group) ?? group;
                       effectivePrevTag = isClose ? '/' + tagName : tagName;
                     }
                   }
@@ -1457,13 +1500,13 @@ async function minifyHTML(value, options, partialMarkup) {
               if (prevTag === '/nobr' || prevTag === 'wbr') {
                 if (/^\s/.test(text)) {
                   let tagIndex = buffer.length - 1;
-                  while (tagIndex > 0 && buffer[tagIndex].lastIndexOf('<' + prevTag) !== 0) {
+                  while (tagIndex > 0 && (buffer[tagIndex] ?? '').lastIndexOf('<' + prevTag) !== 0) {
                     tagIndex--;
                   }
                   trimTrailingWhitespace(tagIndex - 1, 'br');
                 }
               } else if (inlineTextSet.has(prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag)) {
-                text = collapseWhitespace(text, options, /(?:^|\s)$/.test(currentChars));
+                text = collapseWhitespace(text, options, /(?:^|\s)$/.test(currentChars), false);
               }
             }
             if (prevTag || nextTag) {
@@ -1483,18 +1526,18 @@ async function minifyHTML(value, options, partialMarkup) {
       }
 
       // Finalization phase (sync): Optional tag handling, entity re-encoding, buffer push
-      function charsFinalize(text) {
+      function charsFinalize(/** @type {string} */ text) {
         if (options.removeOptionalTags && text) {
           // UID-attr tokens are padded with `\t`, which would falsely look like leading whitespace;
           // resolve single-token text to its actual content for the space/comment checks below
           let effectiveText = text;
-          if (uidAttrLeadingPattern && text.includes(uidAttr)) {
+          if (uidAttrLeadingPattern && uidAttr && text.includes(uidAttr)) {
             const uidMatch = uidAttrLeadingPattern.exec(text);
             if (uidMatch) {
-              const idx = +uidMatch[1];
+              const idx = +(uidMatch[1] ?? 0);
               const chunks = idx < ignoredCustomMarkupChunks.length ? ignoredCustomMarkupChunks[idx] : null;
               if (chunks != null) {
-                effectiveText = chunks[0];
+                effectiveText = chunks[0] ?? '';
               }
             }
           }
@@ -1530,8 +1573,8 @@ async function minifyHTML(value, options, partialMarkup) {
           }
         }
         if (uidPattern && options.collapseWhitespace && stackNoTrimWhitespace.length) {
-          text = text.replace(uidPattern, function (match, prefix, index) {
-            return ignoredCustomMarkupChunks[+index][0];
+          text = text.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ match, /** @type {string} */ _prefix, /** @type {string} */ index) {
+            return ignoredCustomMarkupChunks[+index]?.[0] ?? match;
           });
         }
         currentChars += text;
@@ -1557,20 +1600,20 @@ async function minifyHTML(value, options, partialMarkup) {
           text = await processScript(text, options, currentAttrs, minifyHTML);
         }
         if (needsMinifyJS) {
-          text = await options.minifyJS(text, false, isModuleScript);
+          text = await /** @type {Function} */ (options.minifyJS)(text, false, isModuleScript);
         }
         if (needsMinifyCSS) {
-          text = await options.minifyCSS(text);
+          text = await /** @type {Function} */ (options.minifyCSS)(text);
         }
         charsFinalize(text);
       })();
     },
-    comment: function (text, nonStandard) {
+    comment: function (/** @type {string} */ text, /** @type {boolean} */ nonStandard) {
       const prefix = nonStandard ? '<!' : '<!--';
       const suffix = nonStandard ? '>' : '-->';
 
       // Finalization phase (sync): Optional tag handling, `htmlmin:ignore` whitespace collapsing, buffer push
-      function commentFinalize(comment) {
+      function commentFinalize(/** @type {string} */ comment) {
         if (options.removeOptionalTags && comment) {
           if (uidIgnorePlaceholderPattern) {
             const match = uidIgnorePlaceholderPattern.exec(comment);
@@ -1579,11 +1622,12 @@ async function minifyHTML(value, options, partialMarkup) {
               // if there’s a pending optional end tag and the ignored content isn’t itself
               // a comment (which per the HTML spec prevents omission), resolve it now,
               // before the UID is pushed to the buffer
-              const idx = +match[1];
+              const idx = +(match[1] ?? 0);
               const content = idx < ignoredMarkupChunks.length ? ignoredMarkupChunks[idx] : null;
               if (optionalEndTag && optionalEndTagEmitted && content != null && !/^\s*<!--/.test(content)) {
                 const firstTagMatch = content.match(/^\s*<([a-zA-Z][^\s/>]*)/);
-                const firstTag = firstTagMatch ? options.name(firstTagMatch[1]) : '';
+                const firstTagGroup = firstTagMatch?.[1] ?? '';
+                const firstTag = firstTagGroup ? (options.name?.(firstTagGroup) ?? firstTagGroup) : '';
                 if (canRemovePrecedingTag(optionalEndTag, firstTag)) {
                   removeEndTag();
                 }
@@ -1611,8 +1655,8 @@ async function minifyHTML(value, options, partialMarkup) {
                 const prevMatch = prevComment.match(uidIgnorePlaceholderPattern);
 
                 if (currentMatch && prevMatch) {
-                  const currentIndex = +currentMatch[1];
-                  const prevIndex = +prevMatch[1];
+                  const currentIndex = +(currentMatch[1] ?? 0);
+                  const prevIndex = +(prevMatch[1] ?? 0);
 
                   // Defensive bounds check to ensure indices are valid
                   if (currentIndex < ignoredMarkupChunks.length && prevIndex < ignoredMarkupChunks.length) {
@@ -1635,10 +1679,10 @@ async function minifyHTML(value, options, partialMarkup) {
                       // Collapse if both sides are element/closing tags or HTML comments, and neither is inline
                       if ((currentTagMatch || currentIsHtmlComment || currentClosingTagMatch) &&
                           (prevTagMatch || prevIsHtmlComment || prevClosingTagMatch)) {
-                        const currentTag = currentTagMatch ? options.name(currentTagMatch[1])
-                          : currentClosingTagMatch ? options.name(currentClosingTagMatch[1]) : null;
-                        const prevTag = prevTagMatch ? options.name(prevTagMatch[1])
-                          : prevClosingTagMatch ? options.name(prevClosingTagMatch[1]) : null;
+                        const currentTag = currentTagMatch ? (options.name?.(currentTagMatch[1] ?? '') ?? currentTagMatch[1] ?? '')
+                          : currentClosingTagMatch ? (options.name?.(currentClosingTagMatch[1] ?? '') ?? currentClosingTagMatch[1] ?? '') : null;
+                        const prevTag = prevTagMatch ? (options.name?.(prevTagMatch[1] ?? '') ?? prevTagMatch[1] ?? '')
+                          : prevClosingTagMatch ? (options.name?.(prevClosingTagMatch[1] ?? '') ?? prevClosingTagMatch[1] ?? '') : null;
 
                         // Don’t collapse between inline elements (HTML comments count as non-inline)
                         if (!inlineElements.has(currentTag) && !inlineElements.has(prevTag)) {
@@ -1676,7 +1720,7 @@ async function minifyHTML(value, options, partialMarkup) {
       }
 
       if (options.removeComments) {
-        if (isIgnoredComment(text, options)) {
+        if (isIgnoredComment(text, /** @type {any} */ (options))) {
           text = prefix + text + suffix;
         } else {
           text = '';
@@ -1686,7 +1730,7 @@ async function minifyHTML(value, options, partialMarkup) {
       }
       commentFinalize(text);
     },
-    doctype: function (doctype) {
+    doctype: function (/** @type {string} */ doctype) {
       buffer.push(options.useShortDoctype
         ? '<!doctype' +
         (options.removeTagWhitespace ? '' : ' ') + 'html>'
@@ -1701,11 +1745,12 @@ async function minifyHTML(value, options, partialMarkup) {
   if (options.minifySVG && svgBlocks.length) {
     const optimized = await Promise.all(
       svgBlocks.map(({ start, end }) =>
-        options.minifySVG(buffer.slice(start, end).join(''))
+        /** @type {Function} */ (options.minifySVG)(buffer.slice(start, end).join(''))
       )
     );
     for (let i = svgBlocks.length - 1; i >= 0; i--) {
-      buffer.splice(svgBlocks[i].start, svgBlocks[i].end - svgBlocks[i].start, optimized[i]);
+      const block = svgBlocks[i];
+      if (block) buffer.splice(block.start, block.end - block.start, optimized[i] ?? '');
     }
   }
 
@@ -1725,9 +1770,9 @@ async function minifyHTML(value, options, partialMarkup) {
   }
 
   return joinResultSegments(buffer, options, uidPattern
-    ? function (str) {
-      return str.replace(uidPattern, function (match, prefix, index, suffix) {
-        let chunk = ignoredCustomMarkupChunks[+index][0];
+    ? function (/** @type {string} */ str) {
+      return str.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ match, /** @type {string} */ prefix, /** @type {string} */ index, /** @type {string} */ suffix) {
+        let chunk = ignoredCustomMarkupChunks[+index]?.[0] ?? match;
         if (options.collapseWhitespace) {
           if (prefix !== '\t') {
             chunk = prefix + chunk;
@@ -1744,14 +1789,20 @@ async function minifyHTML(value, options, partialMarkup) {
       });
     }
     : identity, uidIgnore
-    ? function (str) {
-      return str.replace(new RegExp('<!--' + uidIgnore + '([0-9]+)-->', 'g'), function (match, index) {
-        return ignoredMarkupChunks[+index];
+    ? function (/** @type {string} */ str) {
+      return str.replace(new RegExp('<!--' + uidIgnore + '([0-9]+)-->', 'g'), function (/** @type {string} */ _match, /** @type {string} */ index) {
+        return ignoredMarkupChunks[+index] ?? '';
       });
     }
     : identity);
 }
 
+/**
+ * @param {string[]} results
+ * @param {MinifierOptions} options
+ * @param {Function} restoreCustom
+ * @param {Function} restoreIgnore
+ */
 function joinResultSegments(results, options, restoreCustom, restoreIgnore) {
   let str;
   const maxLineLength = options.maxLineLength;
@@ -1761,15 +1812,16 @@ function joinResultSegments(results, options, restoreCustom, restoreIgnore) {
     let line = ''; const lines = [];
     while (results.length) {
       const len = line.length;
-      const end = results[0].indexOf('\n');
-      const isClosingTag = Boolean(results[0].match(endTag));
+      const cur = results[0] ?? '';
+      const end = cur.indexOf('\n');
+      const isClosingTag = Boolean(cur.match(endTag));
       const shouldKeepSameLine = noNewlinesBeforeTagClose && isClosingTag;
 
       if (end < 0) {
-        line += restoreIgnore(restoreCustom(results.shift()));
+        line += restoreIgnore(restoreCustom(results.shift() ?? ''));
       } else {
-        line += restoreIgnore(restoreCustom(results[0].slice(0, end)));
-        results[0] = results[0].slice(end + 1);
+        line += restoreIgnore(restoreCustom(cur.slice(0, end)));
+        results[0] = cur.slice(end + 1);
       }
       if (len > 0 && line.length > maxLineLength && !shouldKeepSameLine) {
         lines.push(line.slice(0, len));
@@ -1799,13 +1851,14 @@ function joinResultSegments(results, options, restoreCustom, restoreIgnore) {
  * - The first call’s options determine the cache sizes for subsequent calls
  * - Invalid values (NaN, Infinity) fall back to the default size (500); values below `1` are clamped to `1`
  */
+/** @param {MinifierOptions} options */
 function initCaches(options) {
   // Only create caches once (on first call)—sizes are locked after this
   if (!cssMinifyCache) {
     const defaultSize = 500;
 
     // Helper to parse env var—returns parsed number (including 0) or undefined if absent, invalid, or negative
-    const parseEnvCacheSize = (envVar) => {
+    const parseEnvCacheSize = (/** @type {string | undefined} */ envVar) => {
       if (envVar === undefined) return undefined;
       const parsed = Number(envVar);
       if (Number.isNaN(parsed) || !Number.isFinite(parsed) || parsed < 0) {
@@ -1815,7 +1868,7 @@ function initCaches(options) {
     };
 
     // Sanitize a cache size: Non-finite/NaN falls back to `defaultSize`; otherwise clamped to min 1 and floored
-    const sanitizeSize = (size) => Number.isFinite(size) ? Math.max(1, Math.floor(size)) : defaultSize;
+    const sanitizeSize = (/** @type {number} */ size) => Number.isFinite(size) ? Math.max(1, Math.floor(size)) : defaultSize;
 
     // Get cache sizes with precedence: Options > env > default
     const cssSize = options.cacheCSS !== undefined ? options.cacheCSS
@@ -1853,7 +1906,9 @@ export const minify = async function (value, options) {
     getTerser,
     getSwc,
     getSvgo,
-    ...caches
+    cssMinifyCache: caches.cssMinifyCache ?? undefined,
+    jsMinifyCache: caches.jsMinifyCache ?? undefined,
+    svgMinifyCache: caches.svgMinifyCache ?? undefined
   });
   let result = await minifyHTML(value, options);
 
@@ -1862,7 +1917,7 @@ export const minify = async function (value, options) {
     result = mergeConsecutiveScripts(result);
   }
 
-  options.log('minified in: ' + (Date.now() - start) + 'ms');
+  /** @type {Function} */ (options.log)('minified in: ' + (Date.now() - start) + 'ms');
   return result;
 };
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1159,7 +1159,7 @@ async function minifyHTML(value, options, partialMarkup) {
       const match = str.match(/^<\/([\w:-]+)>$/);
       if (match) {
         endTag = match[1] ?? '';
-      } else if (/>$/.test(str) || (buffer[index] = collapseWhitespaceSmart(str, '', nextTag, [], [], options, inlineElements, inlineTextSet))) {
+      } else if (/>$/.test(str) || (buffer[index] = collapseWhitespaceSmart(str, '', nextTag, emptyAttrs, emptyAttrs, options, inlineElements, inlineTextSet))) {
         break;
       }
     }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1690,7 +1690,7 @@ async function minifyHTML(value, options, partialMarkup) {
                           : prevClosingTagMatch ? resolveName(prevClosingTagMatch[1] ?? '') : null;
 
                         // Don’t collapse between inline elements (HTML comments count as non-inline)
-                        if (!inlineElements.has(currentTag) && !inlineElements.has(prevTag)) {
+                        if (!inlineElements.has(currentTag ?? '') && !inlineElements.has(prevTag ?? '')) {
                           // Collapse whitespace respecting context rules
                           let collapsedText = prevText;
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1,5 +1,3 @@
-// Imports
-
 import { HTMLParser, endTag } from './htmlparser.js';
 import TokenChain from './tokenchain.js';
 import { presets, getPreset, getPresetNames } from './presets.js';
@@ -56,250 +54,12 @@ import {
 
 import { processOptions } from './lib/options.js';
 
-// Lazy-load heavy dependencies only when needed
-
-/** @type {Promise<Function> | undefined} */
-let lightningCSSPromise;
-async function getLightningCSS() {
-  if (!lightningCSSPromise) {
-    lightningCSSPromise = import('lightningcss').then(m => m.transform);
-  }
-  return lightningCSSPromise;
-}
-
-/** @type {Promise<Function> | undefined} */
-let terserPromise;
-async function getTerser() {
-  if (!terserPromise) {
-    terserPromise = import('terser').then(m => m.minify);
-  }
-  return terserPromise;
-}
-
-/** @type {Promise<any> | undefined} */
-let swcPromise;
-async function getSwc() {
-  if (!swcPromise) {
-    swcPromise = import('@swc/core')
-      .then(m => m.default || m)
-      .catch(() => {
-        throw new Error(
-          'The swc minifier requires @swc/core to be installed.\n' +
-          'Install it with: npm install @swc/core'
-        );
-      });
-  }
-  return swcPromise;
-}
-
-/** @type {Promise<Function> | undefined} */
-let svgoPromise;
-async function getSvgo() {
-  if (!svgoPromise) {
-    svgoPromise = import('svgo').then(m => m.optimize);
-  }
-  return svgoPromise;
-}
-
-/** @type {Promise<Function> | undefined} */
-let decodeHTMLPromise;
-async function getDecodeHTML() {
-  if (!decodeHTMLPromise) {
-    decodeHTMLPromise = import('entities').then(m => m.decodeHTML);
-  }
-  return decodeHTMLPromise;
-}
-
-// Minification caches (initialized on first use with configurable sizes)
-/** @type {LRU | null} */
-let cssMinifyCache = null;
-/** @type {LRU | null} */
-let jsMinifyCache = null;
-/** @type {LRU | null} */
-let svgMinifyCache = null;
-
-// Pre-compiled patterns for script merging (avoid repeated allocation in hot path)
-const RE_SCRIPT_ATTRS = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
-const RE_SCRIPT_OPEN = /<script(?=[\s>])/gi; // Finds tag start; use `findTagEnd()` for the actual closing `>`
-const RE_SCRIPT_CLOSE = /<\/script\s*>/gi;
-const SCRIPT_BOOL_ATTRS = new Set(['async', 'defer', 'nomodule']);
-const DEFAULT_JS_TYPES = new Set(['', 'text/javascript', 'application/javascript']);
-
-// Pre-compiled patterns for buffer scanning
-const RE_START_TAG = /^<[^/!]/;
-const RE_END_TAG = /^<\//;
-
-// Pre-compiled patterns for `htmlmin:ignore` block content analysis
-const RE_HTML_COMMENT_START = /^\s*<!--/;
-const RE_CLOSING_TAG_START = /^\s*<\/([a-zA-Z][\w:-]*)/;
-const RE_LAST_HTML_TAG = /[\s\S]*<(\/?[a-zA-Z][\w:-]*)/;
-
-// HTML encoding types for annotation-xml (MathML)
-const RE_HTML_ENCODING = /^(text\/html|application\/xhtml\+xml)$/i;
-
-// Script merging
-
-/**
- * Find the index of the `>` that closes an opening tag, correctly skipping
- * over quoted attribute values (which may contain `>`).
- * @param {string} html
- * @param {number} pos - Start position (just after the tag name)
- * @returns {number} Index of the closing `>`, or -1 if not found
- */
-function findTagEnd(html, pos) {
-  let i = pos;
-  while (i < html.length) {
-    const ch = html[i];
-    if (ch === '>') return i;
-    if (ch === '"' || ch === "'") {
-      const q = ch;
-      i++;
-      while (i < html.length && html[i] !== q) i++;
-    }
-    i++;
-  }
-  return -1;
-}
-
-/**
- * Merge consecutive inline script tags into one (`mergeConsecutiveScripts`).
- * Only merges scripts that are compatible:
- * - Both inline (no `src` attribute)
- * - Same `type` (or both default JavaScript)
- * - No conflicting attributes (`async`, `defer`, `nomodule`, different `nonce`)
- *
- * Uses a scanner rather than a regex to locate script boundaries, so literal
- * `</script>` strings inside script content are handled correctly per the HTML
- * spec (raw text ends at the first `</script>`).
- *
- * @param {string} html - The HTML string to process
- * @returns {string} HTML with consecutive scripts merged
- */
-function mergeConsecutiveScripts(html) {
-  // Parse an attribute string into a name→value map
-  const parseAttrs = (/** @type {string} */ attrStr) => {
-    /** @type {Record<string, string>} */
-    const attrs = {};
-    RE_SCRIPT_ATTRS.lastIndex = 0;
-    let m;
-    while ((m = RE_SCRIPT_ATTRS.exec(attrStr)) !== null) {
-      const name = (m[1] ?? '').toLowerCase();
-      const value = m[2] ?? m[3] ?? m[4] ?? '';
-      attrs[name] = value;
-    }
-    return attrs;
-  };
-
-  let changed = true;
-
-  // Keep merging until no more changes (handles chains of 3+ scripts)
-  while (changed) {
-    changed = false;
-    RE_SCRIPT_OPEN.lastIndex = 0;
-    let m1;
-
-    while ((m1 = RE_SCRIPT_OPEN.exec(html)) !== null) {
-      // Use findTagEnd() to get the real closing '>', skipping quoted attribute values
-      const tagEnd1 = findTagEnd(html, m1.index + 7);
-      if (tagEnd1 === -1) break;
-
-      const attrs1Str = html.slice(m1.index + 7, tagEnd1);
-      const contentStart1 = tagEnd1 + 1;
-
-      // Find end of this script’s content (first `</script>`—per HTML spec, raw text ends here)
-      RE_SCRIPT_CLOSE.lastIndex = contentStart1;
-      const close1 = RE_SCRIPT_CLOSE.exec(html);
-      if (!close1) break;
-
-      const content1 = html.slice(contentStart1, close1.index);
-      const afterClose1 = close1.index + close1[0].length;
-
-      // Skip optional whitespace and check for a consecutive <script> tag
-      let i = afterClose1;
-      while (i < html.length && (html[i] === ' ' || html[i] === '\t' || html[i] === '\n' || html[i] === '\r' || html[i] === '\f')) i++;
-      if (html.slice(i, i + 7).toLowerCase() !== '<script' || (html.charAt(i + 7) !== '>' && !/\s/.test(html.charAt(i + 7)))) {
-        RE_SCRIPT_OPEN.lastIndex = afterClose1;
-        continue;
-      }
-
-      const tagStart2 = i;
-      const tagEnd2 = findTagEnd(html, tagStart2 + 7);
-      if (tagEnd2 === -1) break;
-
-      const attrs2Str = html.slice(tagStart2 + 7, tagEnd2);
-      const contentStart2 = tagEnd2 + 1;
-
-      // Find end of second script’s content
-      RE_SCRIPT_CLOSE.lastIndex = contentStart2;
-      const close2 = RE_SCRIPT_CLOSE.exec(html);
-      if (!close2) break;
-
-      const content2 = html.slice(contentStart2, close2.index);
-      const afterClose2 = close2.index + close2[0].length;
-
-      const a1 = parseAttrs(attrs1Str);
-      const a2 = parseAttrs(attrs2Str);
-
-      // Check for `src`—cannot merge external scripts
-      if ('src' in a1 || 'src' in a2) {
-        RE_SCRIPT_OPEN.lastIndex = afterClose1;
-        continue;
-      }
-
-      // Check `type` compatibility (both must be default JS)
-      // Non-JS types (modules, JSON, etc.) must not be merged:
-      // Module scripts have per-script lexical scope, and non-JS content (e.g., JSON)
-      // is not concatenable; even identical non-JS types are incompatible
-      const type1 = (a1.type || '').toLowerCase();
-      const type2 = (a2.type || '').toLowerCase();
-      if (!DEFAULT_JS_TYPES.has(type1) || !DEFAULT_JS_TYPES.has(type2)) {
-        RE_SCRIPT_OPEN.lastIndex = afterClose1;
-        continue;
-      }
-
-      // Check for conflicting boolean attributes
-      let boolConflict = false;
-      for (const attr of SCRIPT_BOOL_ATTRS) {
-        if ((attr in a1) !== (attr in a2)) { boolConflict = true; break; }
-      }
-
-      // Check `nonce`—must be same or both absent
-      if (boolConflict || a1.nonce !== a2.nonce) {
-        RE_SCRIPT_OPEN.lastIndex = afterClose1;
-        continue;
-      }
-
-      // Scripts are compatible—merge them
-      changed = true;
-
-      // Combine content—use semicolon normally, newline only for trailing `//` comments
-      const c1 = content1.trim();
-      const c2 = content2.trim();
-      let mergedContent;
-      if (c1 && c2) {
-        // Check if last line of c1 contains `//` (single-line comment)
-        // If so, use newline to terminate it; otherwise use semicolon (if not already present)
-        const lastLine = c1.slice(c1.lastIndexOf('\n') + 1);
-        const separator = lastLine.includes('//') ? '\n' : (c1.endsWith(';') ? '' : ';');
-        mergedContent = c1 + separator + c2;
-      } else {
-        mergedContent = c1 || c2;
-      }
-
-      // Use first script’s attributes (they should be compatible)
-      html = html.slice(0, m1.index) + `<script${attrs1Str}>${mergedContent}</script>` + html.slice(afterClose2);
-      break; // Restart scanning (outer while loop)
-    }
-  }
-
-  return html;
-}
-
 // Type definitions
 
 /**
  * @typedef {Object} HTMLAttribute
  *  Representation of an attribute from the HTML parser.
+ *  Internal counterpart: `HTMLAttribute` in `lib/attributes.js`—keep in sync.
  *
  * @prop {string} name
  * @prop {string} [value]
@@ -715,6 +475,245 @@ function mergeConsecutiveScripts(html) {
  * @prop {Function} [parentName] - Internal: Preserved name function during namespace transitions
  * @prop {Function} [htmlName] - Internal: HTML name function preserved from outer context
  */
+
+// Lazy-load heavy dependencies only when needed
+
+/** @type {Promise<Function> | undefined} */
+let lightningCSSPromise;
+async function getLightningCSS() {
+  if (!lightningCSSPromise) {
+    lightningCSSPromise = import('lightningcss').then(m => m.transform);
+  }
+  return lightningCSSPromise;
+}
+
+/** @type {Promise<Function> | undefined} */
+let terserPromise;
+async function getTerser() {
+  if (!terserPromise) {
+    terserPromise = import('terser').then(m => m.minify);
+  }
+  return terserPromise;
+}
+
+/** @type {Promise<any> | undefined} */
+let swcPromise;
+async function getSwc() {
+  if (!swcPromise) {
+    swcPromise = import('@swc/core')
+      .then(m => m.default || m)
+      .catch(() => {
+        throw new Error(
+          'The swc minifier requires @swc/core to be installed.\n' +
+          'Install it with: npm install @swc/core'
+        );
+      });
+  }
+  return swcPromise;
+}
+
+/** @type {Promise<Function> | undefined} */
+let svgoPromise;
+async function getSvgo() {
+  if (!svgoPromise) {
+    svgoPromise = import('svgo').then(m => m.optimize);
+  }
+  return svgoPromise;
+}
+
+/** @type {Promise<Function> | undefined} */
+let decodeHTMLPromise;
+async function getDecodeHTML() {
+  if (!decodeHTMLPromise) {
+    decodeHTMLPromise = import('entities').then(m => m.decodeHTML);
+  }
+  return decodeHTMLPromise;
+}
+
+// Minification caches (initialized on first use with configurable sizes)
+/** @type {LRU | null} */
+let cssMinifyCache = null;
+/** @type {LRU | null} */
+let jsMinifyCache = null;
+/** @type {LRU | null} */
+let svgMinifyCache = null;
+
+// Pre-compiled patterns for script merging (avoid repeated allocation in hot path)
+const RE_SCRIPT_ATTRS = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
+const RE_SCRIPT_OPEN = /<script(?=[\s>])/gi; // Finds tag start; use `findTagEnd()` for the actual closing `>`
+const RE_SCRIPT_CLOSE = /<\/script\s*>/gi;
+const SCRIPT_BOOL_ATTRS = new Set(['async', 'defer', 'nomodule']);
+const DEFAULT_JS_TYPES = new Set(['', 'text/javascript', 'application/javascript']);
+
+// Pre-compiled patterns for buffer scanning
+const RE_START_TAG = /^<[^/!]/;
+const RE_END_TAG = /^<\//;
+
+// Pre-compiled patterns for `htmlmin:ignore` block content analysis
+const RE_HTML_COMMENT_START = /^\s*<!--/;
+const RE_CLOSING_TAG_START = /^\s*<\/([a-zA-Z][\w:-]*)/;
+const RE_LAST_HTML_TAG = /[\s\S]*<(\/?[a-zA-Z][\w:-]*)/;
+
+// HTML encoding types for annotation-xml (MathML)
+const RE_HTML_ENCODING = /^(text\/html|application\/xhtml\+xml)$/i;
+
+// Script merging
+
+/**
+ * Find the index of the `>` that closes an opening tag, correctly skipping
+ * over quoted attribute values (which may contain `>`).
+ * @param {string} html
+ * @param {number} pos - Start position (just after the tag name)
+ * @returns {number} Index of the closing `>`, or -1 if not found
+ */
+function findTagEnd(html, pos) {
+  let i = pos;
+  while (i < html.length) {
+    const ch = html[i];
+    if (ch === '>') return i;
+    if (ch === '"' || ch === "'") {
+      const q = ch;
+      i++;
+      while (i < html.length && html[i] !== q) i++;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Merge consecutive inline script tags into one (`mergeConsecutiveScripts`).
+ * Only merges scripts that are compatible:
+ * - Both inline (no `src` attribute)
+ * - Same `type` (or both default JavaScript)
+ * - No conflicting attributes (`async`, `defer`, `nomodule`, different `nonce`)
+ *
+ * Uses a scanner rather than a regex to locate script boundaries, so literal
+ * `</script>` strings inside script content are handled correctly per the HTML
+ * spec (raw text ends at the first `</script>`).
+ *
+ * @param {string} html - The HTML string to process
+ * @returns {string} HTML with consecutive scripts merged
+ */
+function mergeConsecutiveScripts(html) {
+  // Parse an attribute string into a name→value map
+  const parseAttrs = (/** @type {string} */ attrStr) => {
+    /** @type {Record<string, string>} */
+    const attrs = {};
+    RE_SCRIPT_ATTRS.lastIndex = 0;
+    let m;
+    while ((m = RE_SCRIPT_ATTRS.exec(attrStr)) !== null) {
+      const name = (m[1] ?? '').toLowerCase();
+      const value = m[2] ?? m[3] ?? m[4] ?? '';
+      attrs[name] = value;
+    }
+    return attrs;
+  };
+
+  let changed = true;
+
+  // Keep merging until no more changes (handles chains of 3+ scripts)
+  while (changed) {
+    changed = false;
+    RE_SCRIPT_OPEN.lastIndex = 0;
+    let m1;
+
+    while ((m1 = RE_SCRIPT_OPEN.exec(html)) !== null) {
+      // Use findTagEnd() to get the real closing '>', skipping quoted attribute values
+      const tagEnd1 = findTagEnd(html, m1.index + 7);
+      if (tagEnd1 === -1) break;
+
+      const attrs1Str = html.slice(m1.index + 7, tagEnd1);
+      const contentStart1 = tagEnd1 + 1;
+
+      // Find end of this script’s content (first `</script>`—per HTML spec, raw text ends here)
+      RE_SCRIPT_CLOSE.lastIndex = contentStart1;
+      const close1 = RE_SCRIPT_CLOSE.exec(html);
+      if (!close1) break;
+
+      const content1 = html.slice(contentStart1, close1.index);
+      const afterClose1 = close1.index + close1[0].length;
+
+      // Skip optional whitespace and check for a consecutive <script> tag
+      let i = afterClose1;
+      while (i < html.length && (html[i] === ' ' || html[i] === '\t' || html[i] === '\n' || html[i] === '\r' || html[i] === '\f')) i++;
+      if (html.slice(i, i + 7).toLowerCase() !== '<script' || (html.charAt(i + 7) !== '>' && !/\s/.test(html.charAt(i + 7)))) {
+        RE_SCRIPT_OPEN.lastIndex = afterClose1;
+        continue;
+      }
+
+      const tagStart2 = i;
+      const tagEnd2 = findTagEnd(html, tagStart2 + 7);
+      if (tagEnd2 === -1) break;
+
+      const attrs2Str = html.slice(tagStart2 + 7, tagEnd2);
+      const contentStart2 = tagEnd2 + 1;
+
+      // Find end of second script’s content
+      RE_SCRIPT_CLOSE.lastIndex = contentStart2;
+      const close2 = RE_SCRIPT_CLOSE.exec(html);
+      if (!close2) break;
+
+      const content2 = html.slice(contentStart2, close2.index);
+      const afterClose2 = close2.index + close2[0].length;
+
+      const a1 = parseAttrs(attrs1Str);
+      const a2 = parseAttrs(attrs2Str);
+
+      // Check for `src`—cannot merge external scripts
+      if ('src' in a1 || 'src' in a2) {
+        RE_SCRIPT_OPEN.lastIndex = afterClose1;
+        continue;
+      }
+
+      // Check `type` compatibility (both must be default JS)
+      // Non-JS types (modules, JSON, etc.) must not be merged:
+      // Module scripts have per-script lexical scope, and non-JS content (e.g., JSON)
+      // is not concatenable; even identical non-JS types are incompatible
+      const type1 = (a1.type || '').toLowerCase();
+      const type2 = (a2.type || '').toLowerCase();
+      if (!DEFAULT_JS_TYPES.has(type1) || !DEFAULT_JS_TYPES.has(type2)) {
+        RE_SCRIPT_OPEN.lastIndex = afterClose1;
+        continue;
+      }
+
+      // Check for conflicting boolean attributes
+      let boolConflict = false;
+      for (const attr of SCRIPT_BOOL_ATTRS) {
+        if ((attr in a1) !== (attr in a2)) { boolConflict = true; break; }
+      }
+
+      // Check `nonce`—must be same or both absent
+      if (boolConflict || a1.nonce !== a2.nonce) {
+        RE_SCRIPT_OPEN.lastIndex = afterClose1;
+        continue;
+      }
+
+      // Scripts are compatible—merge them
+      changed = true;
+
+      // Combine content—use semicolon normally, newline only for trailing `//` comments
+      const c1 = content1.trim();
+      const c2 = content2.trim();
+      let mergedContent;
+      if (c1 && c2) {
+        // Check if last line of c1 contains `//` (single-line comment)
+        // If so, use newline to terminate it; otherwise use semicolon (if not already present)
+        const lastLine = c1.slice(c1.lastIndexOf('\n') + 1);
+        const separator = lastLine.includes('//') ? '\n' : (c1.endsWith(';') ? '' : ';');
+        mergedContent = c1 + separator + c2;
+      } else {
+        mergedContent = c1 || c2;
+      }
+
+      // Use first script’s attributes (they should be compatible)
+      html = html.slice(0, m1.index) + `<script${attrs1Str}>${mergedContent}</script>` + html.slice(afterClose2);
+      break; // Restart scanning (outer while loop)
+    }
+  }
+
+  return html;
+}
 
 /**
  * @param {string} value

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -7,6 +7,21 @@
 
 import { isThenable } from './lib/utils.js';
 
+/**
+ * @typedef {{
+ *   start?: Function,
+ *   end?: Function,
+ *   chars?: Function,
+ *   comment?: Function,
+ *   doctype?: Function,
+ *   continueOnParseError?: boolean | undefined,
+ *   partialMarkup?: boolean | undefined,
+ *   wantsNextTag?: boolean | undefined,
+ *   customAttrSurround?: RegExp[][] | undefined,
+ *   customAttrAssign?: RegExp[] | undefined
+ * }} HTMLParserHandler
+ */
+
 /*
  * Use like so:
  *
@@ -19,7 +34,8 @@ import { isThenable } from './lib/utils.js';
  */
 
 class CaseInsensitiveSet extends Set {
-  has(str) {
+  /** @override */
+  has(/** @type {string} */ str) {
     return super.has(str.toLowerCase());
   }
 }
@@ -54,8 +70,9 @@ const startTagOpen = new RegExp('^<' + qnameCapture);
 export const endTag = new RegExp('^</' + qnameCapture + '[^>]*>');
 
 let IS_REGEX_CAPTURING_BROKEN = false;
-'x'.replace(/x(.)?/g, function (m, g) {
+'x'.replace(/x(.)?/g, function (/** @type {string} */ m, /** @type {string | undefined} */ g) {
   IS_REGEX_CAPTURING_BROKEN = g === '';
+  return m;
 });
 
 // Empty elements
@@ -89,6 +106,11 @@ const attrRegexCache = new WeakMap();
 
 // O(n) helper: Strip all occurrences of `open…close` delimiters, keeping inner content
 // Used instead of a regex replace to avoid O(n²) behavior on adversarial inputs
+/**
+ * @param {string} str
+ * @param {string} open
+ * @param {string} close
+ */
 function stripDelimited(str, open, close) {
   let result = '';
   let i = 0;
@@ -104,6 +126,7 @@ function stripDelimited(str, open, close) {
   return result;
 }
 
+/** @param {HTMLParserHandler} handler */
 function buildAttrRegex(handler) {
   const unquotedValue = handler.continueOnParseError ? singleAttrValueLenientUnquoted : singleAttrValues[2];
   const attrValues = [singleAttrValues[0], singleAttrValues[1], unquotedValue];
@@ -113,10 +136,11 @@ function buildAttrRegex(handler) {
   if (handler.customAttrSurround) {
     const attrClauses = [];
     for (let i = handler.customAttrSurround.length - 1; i >= 0; i--) {
+      const pair = handler.customAttrSurround[i] ?? [];
       attrClauses[i] = '(?:' +
-        '(' + handler.customAttrSurround[i][0].source + ')\\s*' +
+        '(' + (pair[0]?.source ?? '') + ')\\s*' +
         pattern +
-        '\\s*(' + handler.customAttrSurround[i][1].source + ')' +
+        '\\s*(' + (pair[1]?.source ?? '') + ')' +
         ')';
     }
     attrClauses.push('(?:' + pattern + ')');
@@ -125,6 +149,7 @@ function buildAttrRegex(handler) {
   return new RegExp('^\\s*' + pattern);
 }
 
+/** @param {HTMLParserHandler} handler */
 function getAttrRegexForHandler(handler) {
   let cached = attrRegexCache.get(handler);
   if (cached) return cached;
@@ -136,6 +161,7 @@ function getAttrRegexForHandler(handler) {
 // Cache for sticky attribute regexes (`y` flag for position-based matching on full string)
 const attrRegexStickyCache = new WeakMap();
 
+/** @param {HTMLParserHandler} handler */
 function getAttrRegexStickyForHandler(handler) {
   let cached = attrRegexStickyCache.get(handler);
   if (cached) return cached;
@@ -146,6 +172,7 @@ function getAttrRegexStickyForHandler(handler) {
   return compiled;
 }
 
+/** @param {HTMLParserHandler} handler */
 function joinSingleAttrAssigns(handler) {
   return singleAttrAssigns.concat(
     handler.customAttrAssign || []
@@ -158,6 +185,10 @@ function joinSingleAttrAssigns(handler) {
 const NCP = 7;
 
 export class HTMLParser {
+  /**
+   * @param {string} html
+   * @param {HTMLParserHandler} handler
+   */
   constructor(html, handler) {
     this.html = html;
     this.handler = handler;
@@ -168,12 +199,21 @@ export class HTMLParser {
     const fullHtml = this.html;
     const fullLength = fullHtml.length;
 
-    const stack = []; let lastTag;
+    /** @type {Array<{tag: string, lowerTag: string, attrs: Array<{name: string, value?: string, quote?: string, customAssign?: string, customOpen?: string, customClose?: string}>}>} */
+    const stack = [];
+    /** @type {string} */
+    let lastTag = '';
     // Use cached attribute regex for this handler configuration
     const attribute = getAttrRegexForHandler(handler);
     const attributeY = getAttrRegexStickyForHandler(handler);
-    let prevTag = undefined, nextTag = undefined;
-    let prevAttrs = [], nextAttrs = [];
+    /** @type {string | undefined} */
+    let prevTag;
+    /** @type {string | undefined} */
+    let nextTag;
+    /** @type {Array<{name?: string, value?: string}>} */
+    let prevAttrs = [];
+    /** @type {Array<{name?: string, value?: string}>} */
+    let nextAttrs = [];
 
     // Sticky regex versions for position-based matching (avoids string slicing)
     const startTagOpenY = new RegExp(startTagOpen.source.slice(1), 'y');
@@ -193,10 +233,10 @@ export class HTMLParser {
     let lastPos;
 
     // Helper to advance position
-    const advance = (n) => { pos += n; };
+    const advance = (/** @type {number} */ n) => { pos += n; };
 
     // Lazy line/column calculation—only compute on actual errors
-    const getLineColumn = (position) => {
+    const getLineColumn = (/** @type {number} */ position) => {
       let line = 1;
       let column = 1;
       for (let i = 0; i < position; i++) {
@@ -211,7 +251,7 @@ export class HTMLParser {
     };
 
     // Helper to safely extract substring when needed for stacked tag content
-    const sliceFromPos = (startPos) => {
+    const sliceFromPos = (/** @type {number} */ startPos) => {
       return fullHtml.slice(startPos);
     };
 
@@ -239,9 +279,9 @@ export class HTMLParser {
             const endTagMatch = cachedNextEndTag.match;
             cachedNextStartTag = null;
             cachedNextEndTag = null;
-            advance(endTagMatch[0].length);
-            await parseEndTag(endTagMatch[0], endTagMatch[1]);
-            prevTag = '/' + endTagMatch[1].toLowerCase();
+            advance((endTagMatch[0] ?? '').length);
+            await parseEndTag(endTagMatch[0] ?? '', endTagMatch[1] ?? '');
+            prevTag = '/' + (endTagMatch[1] ?? '').toLowerCase();
             prevAttrs = [];
             continue;
           }
@@ -299,9 +339,9 @@ export class HTMLParser {
           endTagY.lastIndex = pos;
           const endTagMatch = endTagY.exec(fullHtml);
           if (endTagMatch) {
-            advance(endTagMatch[0].length);
-            await parseEndTag(endTagMatch[0], endTagMatch[1]);
-            prevTag = '/' + endTagMatch[1].toLowerCase();
+            advance((endTagMatch[0] ?? '').length);
+            await parseEndTag(endTagMatch[0] ?? '', endTagMatch[1] ?? '');
+            prevTag = '/' + (endTagMatch[1] ?? '').toLowerCase();
             prevAttrs = [];
             continue;
           }
@@ -361,12 +401,12 @@ export class HTMLParser {
       } else {
         const stackedTag = lastTag.toLowerCase();
         // Use pre-compiled regex for common tags (`script`, `style`, `noscript`) to avoid regex creation overhead
-        const reStackedTag = preCompiledStackedTags[stackedTag] || reCache[stackedTag] || (reCache[stackedTag] = new RegExp('([\\s\\S]*?)\\x3c/' + stackedTag + '[^>]*>', 'i'));
+        const reStackedTag = /** @type {Record<string, RegExp>} */ (preCompiledStackedTags)[stackedTag] || /** @type {Record<string, RegExp>} */ (reCache)[stackedTag] || (/** @type {Record<string, RegExp>} */ (reCache)[stackedTag] = new RegExp('([\\s\\S]*?)\\x3c/' + stackedTag + '[^>]*>', 'i'));
 
         const remaining = sliceFromPos(pos);
         const m = reStackedTag.exec(remaining);
         if (m && m.index === 0) {
-          let text = m[1];
+          let text = m[1] ?? '';
           if (stackedTag !== 'script' && stackedTag !== 'style' && stackedTag !== 'noscript') {
             text = stripDelimited(stripDelimited(text, '<!--', '-->'), '<![CDATA[', ']]>');
           }
@@ -414,32 +454,38 @@ export class HTMLParser {
 
     if (!handler.partialMarkup) {
       // Clean up any remaining tags
-      await parseEndTag();
+      await parseEndTag('', '');
     }
 
     // Helper to extract minimal attribute info (name/value pairs) from raw attribute matches
     // Used for whitespace collapsing logic—doesn’t need full processing
-    function extractAttrInfo(rawAttrs) {
+    function extractAttrInfo(/** @type {Array<Array<string | undefined>>} */ rawAttrs) {
       if (!rawAttrs || !rawAttrs.length) return [];
 
       const numCustomParts = handler.customAttrSurround ? handler.customAttrSurround.length * NCP : 0;
       const baseIndex = 1 + numCustomParts;
 
-      return rawAttrs.map(args => {
+      return rawAttrs.map((/** @type {Array<string | undefined>} */ args) => {
         // Extract attribute name (always at `baseIndex`)
         const name = args[baseIndex];
         // Extract value from double-quoted (`baseIndex + 2`), single-quoted (`baseIndex + 3`), or unquoted (`baseIndex + 4`)
         const value = args[baseIndex + 2] ?? args[baseIndex + 3] ?? args[baseIndex + 4];
-        return { name: name?.toLowerCase(), value };
-      }).filter(attr => attr.name); // Filter out invalid entries
+        const lowerName = name?.toLowerCase();
+        /** @type {{name?: string, value?: string}} */
+        const entry = {};
+        if (lowerName !== undefined) entry.name = lowerName;
+        if (value !== undefined) entry.value = value;
+        return entry;
+      }).filter((/** @type {{name?: string, value?: string}} */ attr) => attr.name); // Filter out invalid entries
     }
 
-    function parseStartTag(startPos) {
+    function parseStartTag(/** @type {number} */ startPos) {
       startTagOpenY.lastIndex = startPos;
       const start = startTagOpenY.exec(fullHtml);
       if (start) {
+        /** @type {{tagName: string, attrs: Array<Array<string|undefined>>, advance: number, unarySlash?: string}} */
         const match = {
-          tagName: start[1],
+          tagName: start[1] ?? '',
           attrs: [],
           advance: 0
         };
@@ -582,19 +628,21 @@ export class HTMLParser {
         startTagCloseY.lastIndex = currentPos;
         end = startTagCloseY.exec(fullHtml);
         if (end) {
-          match.unarySlash = end[1];
-          consumed += end[0].length;
+          match.unarySlash = end[1] ?? '';
+          consumed += (end[0] ?? '').length;
           match.advance = consumed;
           return match;
         }
       }
+      return undefined;
     }
 
-    function findTagInCurrentTable(tagName) {
+    function findTagInCurrentTable(/** @type {string} */ tagName) {
       let pos;
       const needle = tagName.toLowerCase();
       for (pos = stack.length - 1; pos >= 0; pos--) {
-        const currentTag = stack[pos].lowerTag;
+        const entry = stack[pos];
+        const currentTag = entry?.lowerTag;
         if (currentTag === needle) {
           return pos;
         }
@@ -606,18 +654,19 @@ export class HTMLParser {
       return -1;
     }
 
-    async function parseEndTagAt(pos) {
+    async function parseEndTagAt(/** @type {number} */ pos) {
       // Close all open elements up to `pos` (mirrors `parseEndTag`’s core branch)
       for (let i = stack.length - 1; i >= pos; i--) {
+        const entry = /** @type {NonNullable<(typeof stack)[number]>} */ (stack[i]);
         if (handler.end) {
-          await handler.end(stack[i].tag, stack[i].attrs, true);
+          await handler.end(entry.tag, entry.attrs, true);
         }
       }
       stack.length = pos;
-      lastTag = pos && stack[pos - 1].tag;
+      lastTag = pos ? (stack[pos - 1]?.tag ?? '') : '';
     }
 
-    async function closeIfFoundInCurrentTable(tagName) {
+    async function closeIfFoundInCurrentTable(/** @type {string} */ tagName) {
       const pos = findTagInCurrentTable(tagName);
       if (pos >= 0) {
         // Close at the specific index to avoid re-searching
@@ -627,7 +676,7 @@ export class HTMLParser {
       return false;
     }
 
-    async function handleStartTag(match) {
+    async function handleStartTag(/** @type {{tagName: string, attrs: Array<Array<string | undefined>>, advance: number, unarySlash?: string}} */ match) {
       const tagName = match.tagName;
       let unarySlash = match.unarySlash;
 
@@ -669,17 +718,18 @@ export class HTMLParser {
 
       const unary = empty.has(tagName) || (tagName === 'html' && lastTag === 'head') || !!unarySlash;
 
-      const attrs = match.attrs.map(function (args) {
+      const attrs = match.attrs.map(function (/** @type {Array<string | undefined>} */ args) {
+        /** @type {string | undefined} */
         let name, value, customOpen, customClose, customAssign, quote;
 
         // Hackish workaround for Firefox bug, https://bugzilla.mozilla.org/show_bug.cgi?id=369778
-        if (IS_REGEX_CAPTURING_BROKEN && args[0].indexOf('""') === -1) {
+        if (IS_REGEX_CAPTURING_BROKEN && (args[0] ?? '').indexOf('""') === -1) {
           if (args[3] === '') { delete args[3]; }
           if (args[4] === '') { delete args[4]; }
           if (args[5] === '') { delete args[5]; }
         }
 
-        function populate(index) {
+        function populate(/** @type {number} */ index) {
           customAssign = args[index];
           value = args[index + 1];
           if (typeof value !== 'undefined') {
@@ -690,7 +740,7 @@ export class HTMLParser {
             return '\'';
           }
           value = args[index + 3];
-          if (typeof value === 'undefined' && fillAttrs.has(name)) {
+          if (typeof value === 'undefined' && name && fillAttrs.has(name)) {
             value = name;
           }
           return '';
@@ -714,8 +764,8 @@ export class HTMLParser {
         }
 
         return {
-          name,
-          value,
+          name: name ?? '',
+          ...(value !== undefined && { value }),
           customAssign: customAssign || '=',
           customOpen: customOpen || '',
           customClose: customClose || '',
@@ -737,18 +787,18 @@ export class HTMLParser {
       }
     }
 
-    function findTag(tagName) {
+    function findTag(/** @type {string} */ tagName) {
       let pos;
       const needle = tagName.toLowerCase();
       for (pos = stack.length - 1; pos >= 0; pos--) {
-        if (stack[pos].lowerTag === needle) {
+        if (stack[pos]?.lowerTag === needle) {
           break;
         }
       }
       return pos;
     }
 
-    async function parseEndTag(tag, tagName) {
+    async function parseEndTag(/** @type {string} */ tag, /** @type {string} */ tagName) {
       let pos;
 
       // Find the closest opened tag of the same type
@@ -762,13 +812,13 @@ export class HTMLParser {
         // Close all the open elements, up the stack
         for (let i = stack.length - 1; i >= pos; i--) {
           if (handler.end) {
-            handler.end(stack[i].tag, stack[i].attrs, i > pos || !tag);
+            handler.end(stack[i]?.tag, stack[i]?.attrs, i > pos || !tag);
           }
         }
 
         // Remove the open elements from the stack
         stack.length = pos;
-        lastTag = pos && stack[pos - 1].tag;
+        lastTag = pos ? (stack[pos - 1]?.tag ?? '') : '';
       } else if (handler.partialMarkup && tagName) {
         // In partial markup mode, preserve stray end tags
         if (handler.end) {

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -134,6 +134,9 @@ function buildAttrRegex(handler) {
     '(?:\\s*(' + joinSingleAttrAssigns(handler) + ')' +
     '[ \\t\\n\\f\\r]*(?:' + attrValues.join('|') + '))?';
   if (handler.customAttrSurround) {
+    if (!Array.isArray(handler.customAttrSurround)) {
+      throw new Error('`customAttrSurround` must be an array of `[RegExp, RegExp]` pairs');
+    }
     const attrClauses = [];
     for (let i = handler.customAttrSurround.length - 1; i >= 0; i--) {
       const pair = handler.customAttrSurround[i];

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -7,6 +7,10 @@
 
 import { isThenable } from './lib/utils.js';
 
+/** @import { HTMLAttribute } from './lib/attributes.js' */
+
+// Type definitions
+
 /**
  * @typedef {{
  *   start?: Function,
@@ -205,7 +209,7 @@ export class HTMLParser {
     const fullHtml = this.html;
     const fullLength = fullHtml.length;
 
-    /** @type {Array<{tag: string, lowerTag: string, attrs: Array<{name: string, value?: string, quote?: string, customAssign?: string, customOpen?: string, customClose?: string}>}>} */
+    /** @type {Array<{tag: string, lowerTag: string, attrs: HTMLAttribute[]}>} */
     const stack = [];
     /** @type {string} */
     let lastTag = '';
@@ -216,9 +220,9 @@ export class HTMLParser {
     let prevTag;
     /** @type {string | undefined} */
     let nextTag;
-    /** @type {Array<{name?: string, value?: string}>} */
+    /** @type {HTMLAttribute[]} */
     let prevAttrs = [];
-    /** @type {Array<{name?: string, value?: string}>} */
+    /** @type {HTMLAttribute[]} */
     let nextAttrs = [];
 
     // Sticky regex versions for position-based matching (avoids string slicing)
@@ -469,13 +473,13 @@ export class HTMLParser {
       const numCustomParts = handler.customAttrSurround ? handler.customAttrSurround.length * NCP : 0;
       const baseIndex = 1 + numCustomParts;
 
-      return rawAttrs.map((/** @type {Array<string | undefined>} */ args) => {
+      return /** @type {HTMLAttribute[]} */ (rawAttrs.map((/** @type {Array<string | undefined>} */ args) => {
         // Extract attribute name (always at `baseIndex`)
         const name = args[baseIndex];
         // Extract value from double-quoted (`baseIndex + 2`), single-quoted (`baseIndex + 3`), or unquoted (`baseIndex + 4`)
         const value = args[baseIndex + 2] ?? args[baseIndex + 3] ?? args[baseIndex + 4];
-        return /** @type {{name?: string, value?: string}} */ ({ name: name?.toLowerCase(), value });
-      }).filter((/** @type {{name?: string, value?: string}} */ attr) => attr.name); // Filter out invalid entries
+        return { name: name?.toLowerCase() ?? '', value };
+      }).filter(attr => attr.name)); // Filter out invalid entries
     }
 
     function parseStartTag(/** @type {number} */ startPos) {
@@ -717,7 +721,7 @@ export class HTMLParser {
 
       const unary = empty.has(tagName) || (tagName === 'html' && lastTag === 'head') || !!unarySlash;
 
-      const attrs = match.attrs.map(function (/** @type {Array<string | undefined>} */ args) {
+      const attrs = /** @type {HTMLAttribute[]} */ (match.attrs.map(function (/** @type {Array<string | undefined>} */ args) {
         /** @type {string | undefined} */
         let name, value, customOpen, customClose, customAssign, quote;
 
@@ -770,7 +774,7 @@ export class HTMLParser {
           customClose: customClose || '',
           quote: quote || ''
         };
-      });
+      }));
 
       if (!unary) {
         stack.push({ tag: tagName, lowerTag: tagName.toLowerCase(), attrs });

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -764,7 +764,7 @@ export class HTMLParser {
 
         return {
           name: name ?? '',
-          ...(value !== undefined && { value }),
+          value,
           customAssign: customAssign || '=',
           customOpen: customOpen || '',
           customClose: customClose || '',

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -136,11 +136,14 @@ function buildAttrRegex(handler) {
   if (handler.customAttrSurround) {
     const attrClauses = [];
     for (let i = handler.customAttrSurround.length - 1; i >= 0; i--) {
-      const pair = handler.customAttrSurround[i] ?? [];
+      const pair = handler.customAttrSurround[i];
+      if (!Array.isArray(pair) || !(pair[0] instanceof RegExp) || !(pair[1] instanceof RegExp)) {
+        throw new Error('`customAttrSurround` entries must be `[RegExp, RegExp]` pairs');
+      }
       attrClauses[i] = '(?:' +
-        '(' + (pair[0]?.source ?? '') + ')\\s*' +
+        '(' + pair[0].source + ')\\s*' +
         pattern +
-        '\\s*(' + (pair[1]?.source ?? '') + ')' +
+        '\\s*(' + pair[1].source + ')' +
         ')';
     }
     attrClauses.push('(?:' + pattern + ')');
@@ -446,9 +449,7 @@ export class HTMLParser {
         const CONTEXT_BEFORE = 50;
         const startPos = Math.max(0, pos - CONTEXT_BEFORE);
         const snippet = fullHtml.slice(startPos, startPos + 200).replace(/\n/g, ' ');
-        throw new Error(
-          `Parse error at line ${loc.line}, column ${loc.column}:\n${snippet}${fullHtml.length > startPos + 200 ? '…' : ''}`
-        );
+        throw new Error(`Parse error at line ${loc.line}, column ${loc.column}:\n${snippet}${fullHtml.length > startPos + 200 ? '…' : ''}`);
       }
     }
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -470,12 +470,7 @@ export class HTMLParser {
         const name = args[baseIndex];
         // Extract value from double-quoted (`baseIndex + 2`), single-quoted (`baseIndex + 3`), or unquoted (`baseIndex + 4`)
         const value = args[baseIndex + 2] ?? args[baseIndex + 3] ?? args[baseIndex + 4];
-        const lowerName = name?.toLowerCase();
-        /** @type {{name?: string, value?: string}} */
-        const entry = {};
-        if (lowerName !== undefined) entry.name = lowerName;
-        if (value !== undefined) entry.value = value;
-        return entry;
+        return /** @type {{name?: string, value?: string}} */ ({ name: name?.toLowerCase(), value });
       }).filter((/** @type {{name?: string, value?: string}} */ attr) => attr.name); // Filter out invalid entries
     }
 

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -1,7 +1,7 @@
 // Imports
 
 /**
- * @typedef {{ name: string, value?: string, quote?: string, customAssign?: string, customOpen?: string, customClose?: string }} HTMLAttr
+ * @typedef {{ name: string, value?: string | undefined, quote?: string, customAssign?: string, customOpen?: string, customClose?: string }} HTMLAttr
  */
 
 import {

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -1,9 +1,3 @@
-// Imports
-
-/**
- * @typedef {{ name: string, value?: string | undefined, quote?: string, customAssign?: string, customOpen?: string, customClose?: string }} HTMLAttr
- */
-
 import {
   RE_EVENT_ATTR_DEFAULT,
   RE_CAN_REMOVE_ATTR_QUOTES,
@@ -24,6 +18,13 @@ import {
 import { trimWhitespace, collapseWhitespaceAll } from './whitespace.js';
 import { shouldMinifyInnerHTML } from './options.js';
 import { identity, isThenable } from './utils.js';
+
+// Type definitions
+
+/**
+ * @typedef {{ name: string, value?: string | undefined, quote?: string, customAssign?: string, customOpen?: string, customClose?: string }} HTMLAttribute
+ *  Internal counterpart of the public typedef in `htmlminifier.js`—keep in sync.
+ */
 
 // Lazy-load entities (used for `decodeEntities` and event-handler attribute decode before `minifyJS`)
 
@@ -77,7 +78,7 @@ function canRemoveAttributeQuotes(value) {
 }
 
 /**
- * @param {HTMLAttr[]} attributes
+ * @param {HTMLAttribute[]} attributes
  * @param {string} attribute
  */
 function attributesInclude(attributes, attribute) {
@@ -93,9 +94,9 @@ function attributesInclude(attributes, attribute) {
  * Remove duplicate attributes from an attribute list.
  * Per HTML spec, when an attribute appears multiple times, the first occurrence wins.
  * Duplicate attributes result in invalid HTML, so only the first is kept.
- * @param {HTMLAttr[]} attrs - Array of attribute objects with `name` property
+ * @param {HTMLAttribute[]} attrs - Array of attribute objects with `name` property
  * @param {boolean} caseSensitive - Whether to compare names case-sensitively (for XML/SVG)
- * @returns {HTMLAttr[]} Deduplicated attribute array (modifies in place and returns)
+ * @returns {HTMLAttribute[]} Deduplicated attribute array (modifies in place and returns)
  */
 function deduplicateAttributes(attrs, caseSensitive) {
   if (attrs.length < 2) {
@@ -122,7 +123,7 @@ function deduplicateAttributes(attrs, caseSensitive) {
  * @param {string} tag
  * @param {string} attrName
  * @param {string} attrValue
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function isAttributeRedundant(tag, attrName, attrValue, attrs) {
   // Fast-path: Check if this element–attribute combination can possibly be redundant
@@ -177,7 +178,7 @@ function keepScriptTypeAttribute(attrValue = '') {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function isExecutableScript(tag, attrs) {
   if (tag !== 'script') {
@@ -198,7 +199,7 @@ function isStyleLinkTypeAttribute(attrValue = '') {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function isStyleElement(tag, attrs) {
   if (tag !== 'style') {
@@ -273,7 +274,7 @@ function isNumberTypeAttribute(attrName, tag) {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  * @param {string} value
  */
 function isLinkType(tag, attrs, value) {
@@ -290,7 +291,7 @@ function isLinkType(tag, attrs, value) {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  * @param {string} attrName
  */
 function isMediaQuery(tag, attrs, attrName) {
@@ -307,7 +308,7 @@ function isSrcset(attrName, tag) {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function isMetaViewport(tag, attrs) {
   if (tag !== 'meta') {
@@ -323,7 +324,7 @@ function isMetaViewport(tag, attrs) {
 
 /**
  * @param {string} tag
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function isContentSecurityPolicy(tag, attrs) {
   if (tag !== 'meta') {
@@ -356,7 +357,7 @@ function canDeleteEmptyAttribute(tag, attrName, attrValue, options) {
 
 /**
  * @param {string} name
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function hasAttrName(name, attrs) {
   for (const attr of attrs) {
@@ -380,7 +381,7 @@ const valueWhitespaceExemptElements = new Set(['button', 'data', 'input', 'optio
  * @param {string} attrName
  * @param {string} attrValue
  * @param {Record<string, any>} options
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute[]} attrs
  * @param {Function} minifyHTMLSelf
  */
 function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTMLSelf) {
@@ -598,8 +599,8 @@ function chooseAttributeQuote(attrValue, options) {
 // Returns the normalized attribute object directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
 /**
- * @param {HTMLAttr} attr
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute} attr
+ * @param {HTMLAttribute[]} attrs
  * @param {string} tag
  * @param {Record<string, any>} options
  * @param {Function} minifyHTML
@@ -622,8 +623,8 @@ function normalizeAttr(attr, attrs, tag, options, minifyHTML) {
 /**
  * @param {string} attrName
  * @param {string | undefined} attrValue
- * @param {HTMLAttr} attr
- * @param {HTMLAttr[]} attrs
+ * @param {HTMLAttribute} attr
+ * @param {HTMLAttribute[]} attrs
  * @param {string} tag
  * @param {Record<string, any>} options
  * @param {Function} minifyHTML
@@ -653,7 +654,7 @@ function normalizeAttrContinue(attrName, attrValue, attr, attrs, tag, options, m
 /**
  * @param {string} attrName
  * @param {string | undefined} attrValue
- * @param {HTMLAttr} attr
+ * @param {HTMLAttribute} attr
  * @param {string} tag
  * @param {Record<string, any>} options
  */
@@ -675,7 +676,7 @@ function normalizeAttrFinish(attrName, attrValue, attr, tag, options) {
 }
 
 /**
- * @param {{name: string, value?: string, attr: HTMLAttr}} normalized
+ * @param {{name: string, value?: string, attr: HTMLAttribute}} normalized
  * @param {string | boolean | undefined} hasUnarySlash
  * @param {Record<string, any>} options
  * @param {boolean} isLast

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -1,5 +1,9 @@
 // Imports
 
+/**
+ * @typedef {{ name: string, value?: string, quote?: string, customAssign?: string, customOpen?: string, customClose?: string }} HTMLAttr
+ */
+
 import {
   RE_EVENT_ATTR_DEFAULT,
   RE_CAN_REMOVE_ATTR_QUOTES,
@@ -23,6 +27,7 @@ import { identity, isThenable } from './utils.js';
 
 // Lazy-load entities (used for `decodeEntities` and event-handler attribute decode before `minifyJS`)
 
+/** @type {Promise<Function> | undefined} */
 let decodeHTMLStrictPromise;
 async function getDecodeHTMLStrict() {
   if (!decodeHTMLStrictPromise) {
@@ -33,20 +38,30 @@ async function getDecodeHTMLStrict() {
 
 // Validators
 
+/**
+ * @param {string} text
+ * @param {{ignoreCustomComments: RegExp[]}} options
+ */
 function isIgnoredComment(text, options) {
-  for (let i = 0, len = options.ignoreCustomComments.length; i < len; i++) {
-    if (options.ignoreCustomComments[i].test(text)) {
+  // @@ Optimize: `Array.isArray(options.ignoreCustomComments)` runs on every comment node; it could be eliminated once `parseRegExpArray` is tightened to coerce non-arrays to `[]` at setup time
+  if (!Array.isArray(options.ignoreCustomComments)) return false;
+  for (const pattern of options.ignoreCustomComments) {
+    if (pattern.test(text)) {
       return true;
     }
   }
   return false;
 }
 
+/**
+ * @param {string} attrName
+ * @param {{customEventAttributes?: RegExp[]}} options
+ */
 function isEventAttribute(attrName, options) {
   const patterns = options.customEventAttributes;
   if (patterns) {
-    for (let i = patterns.length; i--;) {
-      if (patterns[i].test(attrName)) {
+    for (const pattern of patterns) {
+      if (pattern.test(attrName)) {
         return true;
       }
     }
@@ -55,14 +70,19 @@ function isEventAttribute(attrName, options) {
   return RE_EVENT_ATTR_DEFAULT.test(attrName);
 }
 
+/** @param {string} value */
 function canRemoveAttributeQuotes(value) {
   // https://mathiasbynens.be/notes/unquoted-attribute-values
   return RE_CAN_REMOVE_ATTR_QUOTES.test(value);
 }
 
+/**
+ * @param {HTMLAttr[]} attributes
+ * @param {string} attribute
+ */
 function attributesInclude(attributes, attribute) {
-  for (let i = attributes.length; i--;) {
-    if (attributes[i].name.toLowerCase() === attribute) {
+  for (const attr of attributes) {
+    if (attr.name.toLowerCase() === attribute) {
       return true;
     }
   }
@@ -73,9 +93,9 @@ function attributesInclude(attributes, attribute) {
  * Remove duplicate attributes from an attribute list.
  * Per HTML spec, when an attribute appears multiple times, the first occurrence wins.
  * Duplicate attributes result in invalid HTML, so only the first is kept.
- * @param {Array} attrs - Array of attribute objects with `name` property
+ * @param {HTMLAttr[]} attrs - Array of attribute objects with `name` property
  * @param {boolean} caseSensitive - Whether to compare names case-sensitively (for XML/SVG)
- * @returns {Array} Deduplicated attribute array (modifies in place and returns)
+ * @returns {HTMLAttr[]} Deduplicated attribute array (modifies in place and returns)
  */
 function deduplicateAttributes(attrs, caseSensitive) {
   if (attrs.length < 2) {
@@ -85,8 +105,7 @@ function deduplicateAttributes(attrs, caseSensitive) {
   const seen = new Set();
   let writeIndex = 0;
 
-  for (let i = 0; i < attrs.length; i++) {
-    const attr = attrs[i];
+  for (const attr of attrs) {
     const key = caseSensitive ? attr.name : attr.name.toLowerCase();
 
     if (!seen.has(key)) {
@@ -99,6 +118,12 @@ function deduplicateAttributes(attrs, caseSensitive) {
   return attrs;
 }
 
+/**
+ * @param {string} tag
+ * @param {string} attrName
+ * @param {string} attrValue
+ * @param {HTMLAttr[]} attrs
+ */
 function isAttributeRedundant(tag, attrName, attrValue, attrs) {
   // Fast-path: Check if this element–attribute combination can possibly be redundant
   // before doing expensive string operations
@@ -132,32 +157,35 @@ function isAttributeRedundant(tag, attrName, attrValue, attrs) {
   }
 
   // Check general defaults
-  if (hasGeneralDefault && generalDefaults[attrName] === attrValue) {
+  if (hasGeneralDefault && /** @type {Record<string, string>} */ (generalDefaults)[attrName] === attrValue) {
     return true;
   }
 
   // Check tag-specific defaults
-  return tagHasDefaults && tagDefaults[tag][attrName] === attrValue;
+  return tagHasDefaults && /** @type {Record<string, string>} */ (/** @type {Record<string, unknown>} */ (tagDefaults)[tag])[attrName] === attrValue;
 }
 
 function isScriptTypeAttribute(attrValue = '') {
-  attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
+  attrValue = trimWhitespace(attrValue.split(/;/, 2)[0] ?? '').toLowerCase();
   return attrValue === '' || executableScriptsMimetypes.has(attrValue);
 }
 
 function keepScriptTypeAttribute(attrValue = '') {
-  attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
+  attrValue = trimWhitespace(attrValue.split(/;/, 2)[0] ?? '').toLowerCase();
   return keepScriptsMimetypes.has(attrValue);
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ */
 function isExecutableScript(tag, attrs) {
   if (tag !== 'script') {
     return false;
   }
-  for (let i = 0, len = attrs.length; i < len; i++) {
-    const attrName = attrs[i].name.toLowerCase();
-    if (attrName === 'type') {
-      return isScriptTypeAttribute(attrs[i].value);
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'type') {
+      return isScriptTypeAttribute(attr.value);
     }
   }
   return true;
@@ -168,23 +196,30 @@ function isStyleLinkTypeAttribute(attrValue = '') {
   return attrValue === '' || attrValue === 'text/css';
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ */
 function isStyleElement(tag, attrs) {
   if (tag !== 'style') {
     return false;
   }
-  for (let i = 0, len = attrs.length; i < len; i++) {
-    const attrName = attrs[i].name.toLowerCase();
-    if (attrName === 'type') {
-      return isStyleLinkTypeAttribute(attrs[i].value);
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'type') {
+      return isStyleLinkTypeAttribute(attr.value);
     }
   }
   return true;
 }
 
+/**
+ * @param {string} attrName
+ * @param {string} attrValue
+ */
 function isBooleanAttribute(attrName, attrValue) {
   return isSimpleBoolean.has(attrName) ||
     (attrName === 'draggable' && !isBooleanValue.has(attrValue)) ||
-    (collapsibleValues.has(attrName) && collapsibleValues.get(attrName).has(attrValue));
+    (collapsibleValues.has(attrName) && collapsibleValues.get(attrName)?.has(attrValue));
 }
 
 const uriTypeAttributes = new Map([
@@ -204,6 +239,10 @@ const uriTypeAttributes = new Map([
   ['script', new Set(['src', 'for'])]
 ]);
 
+/**
+ * @param {string} attrName
+ * @param {string} tag
+ */
 function isUriTypeAttribute(attrName, tag) {
   const set = uriTypeAttributes.get(tag);
   return set ? set.has(attrName) : false;
@@ -223,55 +262,87 @@ const numberTypeAttributes = new Map([
   ['td', new Set(['rowspan', 'colspan'])]
 ]);
 
+/**
+ * @param {string} attrName
+ * @param {string} tag
+ */
 function isNumberTypeAttribute(attrName, tag) {
   const set = numberTypeAttributes.get(tag);
   return set ? set.has(attrName) : false;
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ * @param {string} value
+ */
 function isLinkType(tag, attrs, value) {
   if (tag !== 'link') return false;
   const needle = String(value).toLowerCase();
-  for (let i = 0; i < attrs.length; i++) {
-    if (attrs[i].name.toLowerCase() === 'rel') {
-      const tokens = String(attrs[i].value).toLowerCase().split(/\s+/);
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'rel') {
+      const tokens = String(attr.value).toLowerCase().split(/\s+/);
       if (tokens.includes(needle)) return true;
     }
   }
   return false;
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ * @param {string} attrName
+ */
 function isMediaQuery(tag, attrs, attrName) {
   return attrName === 'media' && (isLinkType(tag, attrs, 'stylesheet') || isStyleElement(tag, attrs));
 }
 
+/**
+ * @param {string} attrName
+ * @param {string} tag
+ */
 function isSrcset(attrName, tag) {
   return attrName === 'srcset' && srcsetElements.has(tag);
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ */
 function isMetaViewport(tag, attrs) {
   if (tag !== 'meta') {
     return false;
   }
-  for (let i = 0, len = attrs.length; i < len; i++) {
-    if (attrs[i].name.toLowerCase() === 'name' && attrs[i].value.toLowerCase() === 'viewport') {
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'name' && (attr.value || '').toLowerCase() === 'viewport') {
       return true;
     }
   }
   return false;
 }
 
+/**
+ * @param {string} tag
+ * @param {HTMLAttr[]} attrs
+ */
 function isContentSecurityPolicy(tag, attrs) {
   if (tag !== 'meta') {
     return false;
   }
-  for (let i = 0, len = attrs.length; i < len; i++) {
-    if (attrs[i].name.toLowerCase() === 'http-equiv' && attrs[i].value.toLowerCase() === 'content-security-policy') {
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'http-equiv' && (attr.value || '').toLowerCase() === 'content-security-policy') {
       return true;
     }
   }
   return false;
 }
 
+/**
+ * @param {string} tag
+ * @param {string} attrName
+ * @param {string | undefined} attrValue
+ * @param {{removeEmptyAttributes?: boolean | Function}} options
+ */
 function canDeleteEmptyAttribute(tag, attrName, attrValue, options) {
   const isValueEmpty = !attrValue || attrValue.trim() === '';
   if (!isValueEmpty) {
@@ -283,9 +354,13 @@ function canDeleteEmptyAttribute(tag, attrName, attrValue, options) {
   return (tag === 'input' && attrName === 'value') || reEmptyAttribute.test(attrName);
 }
 
+/**
+ * @param {string} name
+ * @param {HTMLAttr[]} attrs
+ */
 function hasAttrName(name, attrs) {
-  for (let i = attrs.length - 1; i >= 0; i--) {
-    if (attrs[i].name === name) {
+  for (const attr of attrs) {
+    if (attr.name === name) {
       return true;
     }
   }
@@ -300,6 +375,14 @@ const valueWhitespaceExemptElements = new Set(['button', 'data', 'input', 'optio
 
 // Returns the cleaned attribute value directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
+/**
+ * @param {string} tag
+ * @param {string} attrName
+ * @param {string} attrValue
+ * @param {Record<string, any>} options
+ * @param {HTMLAttr[]} attrs
+ * @param {Function} minifyHTMLSelf
+ */
 function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTMLSelf) {
   const isEventAttr = isEventAttribute(attrName, options);
 
@@ -323,9 +406,9 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
       return getDecodeHTMLStrict().then(decode => {
         const decoded = decode(attrValue);
         const result = options.minifyJS(decoded, true);
-        const reEncode = v => (v && v.indexOf('&') !== -1) ? v.replace(RE_AMP_ENTITY, '&amp;$1') : v;
+        const reEncode = (/** @type {string} */ v) => (v && v.indexOf('&') !== -1) ? v.replace(RE_AMP_ENTITY, '&amp;$1') : v;
         if (isThenable(result)) {
-          return result.then(reEncode, err => {
+          return result.then(reEncode, (/** @type {Error} */ err) => {
             if (!options.continueOnMinifyError) throw err;
             options.log && options.log(err);
             return attrValue;
@@ -336,7 +419,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
     }
     const result = options.minifyJS(attrValue, true);
     if (isThenable(result)) {
-      return result.catch(err => {
+      return result.catch((/** @type {Error} */ err) => {
         if (!options.continueOnMinifyError) throw err;
         options.log && options.log(err);
         return attrValue;
@@ -363,8 +446,8 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
     const result = options.minifyURLs(attrValue);
     if (isThenable(result)) {
       return result
-        .then(out => typeof out === 'string' ? out : attrValue)
-        .catch(err => {
+        .then((/** @type {unknown} */ out) => typeof out === 'string' ? out : attrValue)
+        .catch((/** @type {Error} */ err) => {
           if (!options.continueOnMinifyError) throw err;
           options.log && options.log(err);
           return attrValue;
@@ -387,13 +470,13 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
       const cssResult = options.minifyCSS(attrValue, 'inline');
       if (isThenable(cssResult)) {
         return cssResult
-          .then(minified => {
+          .then((/** @type {string} */ minified) => {
             // After minification, check if CSS consists entirely of invalid properties (no values)
             // I.e., `color:` or `margin:;padding:` should be treated as empty
             if (minified && /^(?:[a-z-]+:[;\s]*)+$/i.test(minified)) return '';
             return minified;
           })
-          .catch(err => {
+          .catch((/** @type {Error} */ err) => {
             if (!options.continueOnMinifyError) throw err;
             options.log && options.log(err);
             return originalAttrValue;
@@ -415,8 +498,9 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
       const match = candidate.match(/\s+([1-9][0-9]*w|[0-9]+(?:\.[0-9]+)?x)$/);
       if (match) {
         url = url.slice(0, -match[0].length);
-        const num = +match[1].slice(0, -1);
-        const suffix = match[1].slice(-1);
+        const group = match[1] ?? '';
+        const num = +group.slice(0, -1);
+        const suffix = group.slice(-1);
         if (num !== 1 || suffix !== 'x') {
           descriptor = ' ' + num + suffix;
         }
@@ -424,8 +508,8 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
       const out = options.minifyURLs(url);
       if (isThenable(out)) {
         return out
-          .then(result => (typeof result === 'string' ? result : url) + descriptor)
-          .catch(err => {
+          .then((/** @type {unknown} */ result) => (typeof result === 'string' ? result : url) + descriptor)
+          .catch((/** @type {Error} */ err) => {
             if (!options.continueOnMinifyError) throw err;
             options.log && options.log(err);
             return url + descriptor;
@@ -470,7 +554,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
     const originalAttrValue = attrValue;
     const cssResult = options.minifyCSS(attrValue, 'media');
     if (isThenable(cssResult)) {
-      return cssResult.catch(err => {
+      return cssResult.catch((/** @type {Error} */ err) => {
         if (!options.continueOnMinifyError) throw err;
         options.log && options.log(err);
         return originalAttrValue;
@@ -494,7 +578,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
 /**
  * Choose appropriate quote character for an attribute value
  * @param {string} attrValue - The attribute value
- * @param {Object} options - Minifier options
+ * @param {{quoteCharacter?: string}} options - Minifier options
  * @returns {string} The chosen quote character (`"` or `'`)
  */
 function chooseAttributeQuote(attrValue, options) {
@@ -513,6 +597,13 @@ function chooseAttributeQuote(attrValue, options) {
 
 // Returns the normalized attribute object directly (sync) or as a Promise (async);
 // callers must handle both cases—use `isThenable()` to distinguish
+/**
+ * @param {HTMLAttr} attr
+ * @param {HTMLAttr[]} attrs
+ * @param {string} tag
+ * @param {Record<string, any>} options
+ * @param {Function} minifyHTML
+ */
 function normalizeAttr(attr, attrs, tag, options, minifyHTML) {
   const attrName = options.name(attr.name);
   let attrValue = attr.value;
@@ -528,9 +619,18 @@ function normalizeAttr(attr, attrs, tag, options, minifyHTML) {
 }
 
 // Internal: Handles attribute normalization after entity decoding (if any)
+/**
+ * @param {string} attrName
+ * @param {string | undefined} attrValue
+ * @param {HTMLAttr} attr
+ * @param {HTMLAttr[]} attrs
+ * @param {string} tag
+ * @param {Record<string, any>} options
+ * @param {Function} minifyHTML
+ */
 function normalizeAttrContinue(attrName, attrValue, attr, attrs, tag, options, minifyHTML) {
   if ((options.removeRedundantAttributes &&
-       isAttributeRedundant(tag, attrName, attrValue, attrs)) ||
+       isAttributeRedundant(tag, attrName, attrValue ?? '', attrs)) ||
       (options.removeScriptTypeAttributes && tag === 'script' &&
        attrName === 'type' && isScriptTypeAttribute(attrValue) && !keepScriptTypeAttribute(attrValue)) ||
       (options.removeStyleLinkTypeAttributes && (tag === 'style' || tag === 'link') &&
@@ -541,7 +641,7 @@ function normalizeAttrContinue(attrName, attrValue, attr, attrs, tag, options, m
   if (attrValue) {
     const cleaned = cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTML);
     if (isThenable(cleaned)) {
-      return cleaned.then(v => normalizeAttrFinish(attrName, v, attr, tag, options));
+      return cleaned.then((/** @type {string | undefined} */ v) => normalizeAttrFinish(attrName, v, attr, tag, options));
     }
     return normalizeAttrFinish(attrName, cleaned, attr, tag, options);
   }
@@ -550,6 +650,13 @@ function normalizeAttrContinue(attrName, attrValue, attr, attrs, tag, options, m
 }
 
 // Internal: Final checks and result assembly after value cleaning
+/**
+ * @param {string} attrName
+ * @param {string | undefined} attrValue
+ * @param {HTMLAttr} attr
+ * @param {string} tag
+ * @param {Record<string, any>} options
+ */
 function normalizeAttrFinish(attrName, attrValue, attr, tag, options) {
   if (options.removeEmptyAttributes &&
       canDeleteEmptyAttribute(tag, attrName, attrValue, options)) {
@@ -567,6 +674,13 @@ function normalizeAttrFinish(attrName, attrValue, attr, tag, options) {
   };
 }
 
+/**
+ * @param {{name: string, value?: string, attr: HTMLAttr}} normalized
+ * @param {string | boolean | undefined} hasUnarySlash
+ * @param {Record<string, any>} options
+ * @param {boolean} isLast
+ * @param {string | undefined} uidAttr
+ */
 function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
   const attrName = normalized.name;
   let attrValue = normalized.value;
@@ -578,7 +692,7 @@ function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
   // Determine if need to add/keep quotes
   const shouldAddQuotes = typeof attrValue !== 'undefined' && (
     // If `removeAttributeQuotes` is enabled, add quotes only if they can’t be removed
-    (options.removeAttributeQuotes && (attrValue.indexOf(uidAttr) !== -1 || !canRemoveAttributeQuotes(attrValue))) ||
+    (options.removeAttributeQuotes && ((uidAttr ? attrValue.indexOf(uidAttr) !== -1 : false) || !canRemoveAttributeQuotes(attrValue))) ||
     // If `removeAttributeQuotes` is not enabled, preserve original quote style or add quotes if value requires them
     (!options.removeAttributeQuotes && (attrQuote !== '' || !canRemoveAttributeQuotes(attrValue) ||
       // Special case: With `removeTagWhitespace`, unquoted values that aren’t last will have space added,
@@ -587,6 +701,7 @@ function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
   );
 
   if (shouldAddQuotes) {
+    attrValue = attrValue ?? '';
     // Determine the appropriate quote character
     if (!options.preventAttributesEscaping) {
       // Normal mode: Choose optimal quote type to minimize escaping

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -9,6 +9,10 @@ import { trimWhitespace } from './whitespace.js';
 
 // Wrap CSS declarations for inline styles and media queries
 // This ensures proper context for CSS minification
+/**
+ * @param {string} text
+ * @param {string} type
+ */
 function wrapCSS(text, type) {
   switch (type) {
     case 'inline':
@@ -20,6 +24,10 @@ function wrapCSS(text, type) {
   }
 }
 
+/**
+ * @param {string} text
+ * @param {string} type
+ */
 function unwrapCSS(text, type) {
   let matches;
   switch (type) {
@@ -30,11 +38,15 @@ function unwrapCSS(text, type) {
       matches = text.match(/^@media ([\s\S]*?)\s*{[\s\S]*}$/);
       break;
   }
-  return matches ? matches[1] : text;
+  return matches ? matches[1] ?? text : text;
 }
 
 // Script processing
 
+/**
+ * @param {string} text
+ * @param {{continueOnMinifyError?: boolean, log?: Function}} options
+ */
 function minifyJson(text, options) {
   try {
     return JSON.stringify(JSON.parse(text));
@@ -48,11 +60,11 @@ function minifyJson(text, options) {
   }
 }
 
+/** @param {Array<{name: string, value?: string}>} attrs */
 function hasJsonScriptType(attrs) {
-  for (let i = 0, len = attrs.length; i < len; i++) {
-    const attrName = attrs[i].name.toLowerCase();
-    if (attrName === 'type') {
-      const attrValue = trimWhitespace((attrs[i].value || '').split(/;/, 2)[0]).toLowerCase();
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === 'type') {
+      const attrValue = trimWhitespace((attr.value || '').split(/;/, 2)[0] ?? '').toLowerCase();
       if (jsonScriptTypes.has(attrValue)) {
         return true;
       }
@@ -61,18 +73,24 @@ function hasJsonScriptType(attrs) {
   return false;
 }
 
+/**
+ * @param {string} text
+ * @param {{continueOnMinifyError?: boolean, log?: Function, processScripts?: string[]}} options
+ * @param {Array<{name: string, value?: string | undefined}>} currentAttrs
+ * @param {Function} minifyHTML
+ */
 async function processScript(text, options, currentAttrs, minifyHTML) {
-  for (let i = 0, len = currentAttrs.length; i < len; i++) {
-    const attrName = currentAttrs[i].name.toLowerCase();
+  for (const attr of currentAttrs) {
+    const attrName = attr.name.toLowerCase();
     if (attrName === 'type') {
-      const rawValue = currentAttrs[i].value;
-      const normalizedValue = trimWhitespace((rawValue || '').split(/;/, 2)[0]).toLowerCase();
+      const rawValue = attr.value;
+      const normalizedValue = trimWhitespace((rawValue || '').split(/;/, 2)[0] ?? '').toLowerCase();
       // Minify JSON script types automatically
       if (jsonScriptTypes.has(normalizedValue)) {
         return minifyJson(text, options);
       }
       // Process custom script types if specified
-      if (options.processScripts && options.processScripts.indexOf(rawValue) > -1) {
+      if (options.processScripts && rawValue && options.processScripts.indexOf(rawValue) > -1) {
         return await minifyHTML(text, options);
       }
     }

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -1,5 +1,3 @@
-// Imports
-
 import {
   jsonScriptTypes
 } from './constants.js';

--- a/src/lib/elements.js
+++ b/src/lib/elements.js
@@ -1,5 +1,10 @@
 // Imports
 
+/**
+ * @typedef {{ name: (str: string) => string, log?: Function }} MinifierOptions
+ * @typedef {{ name: string, value?: string }} HTMLAttribute
+ */
+
 import {
   headerElements,
   descriptionElements,
@@ -15,6 +20,10 @@ import { hasAttrName } from './attributes.js';
 
 // Tag omission rules
 
+/**
+ * @param {string} optionalStartTag
+ * @param {string} tag
+ */
 function canRemoveParentTag(optionalStartTag, tag) {
   switch (optionalStartTag) {
     case 'html':
@@ -30,6 +39,10 @@ function canRemoveParentTag(optionalStartTag, tag) {
   return false;
 }
 
+/**
+ * @param {string} optionalEndTag
+ * @param {string} tag
+ */
 function isStartTagMandatory(optionalEndTag, tag) {
   switch (tag) {
     case 'colgroup':
@@ -40,6 +53,10 @@ function isStartTagMandatory(optionalEndTag, tag) {
   return false;
 }
 
+/**
+ * @param {string} optionalEndTag
+ * @param {string} tag
+ */
 function canRemovePrecedingTag(optionalEndTag, tag) {
   switch (optionalEndTag) {
     case 'html':
@@ -79,6 +96,10 @@ function canRemovePrecedingTag(optionalEndTag, tag) {
 
 // Element removal logic
 
+/**
+ * @param {string} tag
+ * @param {Array<{name: string, value?: string}>} attrs
+ */
 function canRemoveElement(tag, attrs) {
   // Elements with `id` attribute must never be removed—they serve as:
   // - Navigation targets (skip links, URL fragments)
@@ -146,20 +167,21 @@ function parseElementSpec(str, options) {
     return null;
   }
 
-  const tag = options.name(match[1]);
-  const attrString = match[2];
+  const tag = options.name(match[1] ?? '');
+  const attrString = match[2] ?? '';
 
   if (!attrString.trim()) {
     return { tag, attrs: null };
   }
 
   // Parse attributes from string
+  /** @type {{[key: string]: string | undefined}} */
   const attrs = {};
   const attrRegex = /([a-zA-Z][\w:-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>/]+)))?/g;
   let attrMatch;
 
   while ((attrMatch = attrRegex.exec(attrString))) {
-    const attrName = options.name(attrMatch[1]);
+    const attrName = options.name(attrMatch[1] ?? '');
     const attrValue = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4];
     // Boolean attributes have no value (undefined)
     attrs[attrName] = attrValue;
@@ -181,7 +203,7 @@ function parseRemoveEmptyElementsExcept(input, options) {
     return [];
   }
 
-  return input.map(item => {
+  return /** @type {Array<{tag: string, attrs: {[x: string]: string | undefined} | null}>} */ (input.map(item => {
     if (typeof item === 'string') {
       const spec = parseElementSpec(item, options);
       if (!spec && options.log) {
@@ -193,7 +215,7 @@ function parseRemoveEmptyElementsExcept(input, options) {
       options.log('Warning: “removeEmptyElementsExcept” specification must be a string, received: ' + typeof item);
     }
     return null;
-  }).filter(Boolean);
+  }).filter(Boolean));
 }
 
 /**

--- a/src/lib/elements.js
+++ b/src/lib/elements.js
@@ -1,10 +1,3 @@
-// Imports
-
-/**
- * @typedef {{ name: (str: string) => string, log?: Function }} MinifierOptions
- * @typedef {{ name: string, value?: string }} HTMLAttribute
- */
-
 import {
   headerElements,
   descriptionElements,
@@ -17,6 +10,14 @@ import {
   cellElements
 } from './constants.js';
 import { hasAttrName } from './attributes.js';
+
+/** @import { HTMLAttribute } from './attributes.js' */
+
+// Type definitions
+
+/**
+ * @typedef {{ name: (str: string) => string, log?: Function }} MinifierOptions
+ */
 
 // Tag omission rules
 
@@ -98,7 +99,7 @@ function canRemovePrecedingTag(optionalEndTag, tag) {
 
 /**
  * @param {string} tag
- * @param {Array<{name: string, value?: string}>} attrs
+ * @param {HTMLAttribute[]} attrs
  */
 function canRemoveElement(tag, attrs) {
   // Elements with `id` attribute must never be removed—they serve as:

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,11 +1,3 @@
-// Imports
-
-/**
- * @typedef {Record<string, any>} MinifierOptions
- */
-
-// @@ Extract a `ProcessedOptions` typedef (with `name`, `log`, `canCollapseWhitespace`, `canTrimWhitespace`,`minifyCSS`, `minifyJS`, `minifyURLs` typed as required, non-optional) to replace the current `Record<string, any>` escape hatch and eliminate the `/** @type {Function} */` casts in htmlminifier.js
-
 import { createUrlMinifier } from './urls.js';
 import { LRU, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
 import { RE_TRAILING_SEMICOLON } from './constants.js';
@@ -13,6 +5,14 @@ import { canCollapseWhitespace, canTrimWhitespace } from './whitespace.js';
 import { wrapCSS, unwrapCSS } from './content.js';
 import { getPreset, getPresetNames } from '../presets.js';
 import { optionDefaults } from './option-definitions.js';
+
+// Type definitions
+
+/**
+ * @typedef {Record<string, any>} MinifierOptions
+ */
+
+// @@ Extract a `ProcessedOptions` typedef (with `name`, `log`, `canCollapseWhitespace`, `canTrimWhitespace`,`minifyCSS`, `minifyJS`, `minifyURLs` typed as required, non-optional) to replace the current `Record<string, any>` escape hatch and eliminate the `/** @type {Function} */` casts in htmlminifier.js
 
 // Helper functions
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -51,7 +51,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
   };
 
   const parseRegExpArray = (/** @type {unknown} */ arr) => {
-    return Array.isArray(arr) ? arr.map(parseRegExp) : arr;
+    return Array.isArray(arr) ? arr.map(parseRegExp) : [];
   };
 
   // Helper for nested arrays (e.g., `customAttrSurround: [[start, end], …]`)

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,5 +1,11 @@
 // Imports
 
+/**
+ * @typedef {Record<string, any>} MinifierOptions
+ */
+
+// @@ Extract a `ProcessedOptions` typedef (with `name`, `log`, `canCollapseWhitespace`, `canTrimWhitespace`,`minifyCSS`, `minifyJS`, `minifyURLs` typed as required, non-optional) to replace the current `Record<string, any>` escape hatch and eliminate the `/** @type {Function} */` casts in htmlminifier.js
+
 import { createUrlMinifier } from './urls.js';
 import { LRU, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
 import { RE_TRAILING_SEMICOLON } from './constants.js';
@@ -10,6 +16,7 @@ import { optionDefaults } from './option-definitions.js';
 
 // Helper functions
 
+/** @param {MinifierOptions} options */
 function shouldMinifyInnerHTML(options) {
   return Boolean(
     options.collapseWhitespace ||
@@ -25,18 +32,12 @@ function shouldMinifyInnerHTML(options) {
 // Main options processor
 
 /**
- * @param {Partial<MinifierOptions>} inputOptions - User-provided options
- * @param {Object} deps - Dependencies from htmlminifier.js
- * @param {Function} deps.getLightningCSS - Function to lazily load Lightning CSS
- * @param {Function} deps.getTerser - Function to lazily load Terser
- * @param {Function} deps.getSwc - Function to lazily load @swc/core
- * @param {Function} deps.getSvgo - Function to lazily load SVGO
- * @param {LRU} deps.cssMinifyCache - CSS minification cache
- * @param {LRU} deps.jsMinifyCache - JS minification cache
- * @param {LRU} deps.svgMinifyCache - SVG minification cache
+ * @param {MinifierOptions} inputOptions - User-provided options
+ * @param {{getLightningCSS?: Function | undefined, getTerser?: Function | undefined, getSwc?: Function | undefined, getSvgo?: Function | undefined, cssMinifyCache?: LRU | undefined, jsMinifyCache?: LRU | undefined, svgMinifyCache?: LRU | undefined}} [deps] - Dependencies from htmlminifier.js
  * @returns {MinifierOptions} Normalized options with defaults applied
  */
 const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getSvgo, cssMinifyCache, jsMinifyCache, svgMinifyCache } = {}) => {
+  /** @type {MinifierOptions} */
   const options = {
     name: lowercase,
     canCollapseWhitespace,
@@ -49,12 +50,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
     minifySVG: null
   };
 
-  const parseRegExpArray = (arr) => {
+  const parseRegExpArray = (/** @type {unknown} */ arr) => {
     return Array.isArray(arr) ? arr.map(parseRegExp) : arr;
   };
 
   // Helper for nested arrays (e.g., `customAttrSurround: [[start, end], …]`)
-  const parseNestedRegExpArray = (arr) => {
+  const parseNestedRegExpArray = (/** @type {unknown} */ arr) => {
     if (!Array.isArray(arr)) return arr;
     return arr.map(item => {
       // If item is an array (a pair), recursively convert each element
@@ -96,13 +97,16 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         options.log = option;
       }
     } else if (key === 'minifyCSS' && typeof option !== 'function') {
-      if (!option) {
+      if (!option || !getLightningCSS || !cssMinifyCache) {
         return;
       }
 
       const lightningCssOptions = typeof option === 'object' ? option : {};
+      // Capture to preserve TypeScript narrowing across the async closure boundary below
+      const cssLoader = getLightningCSS;
+      const cssCache = cssMinifyCache;
 
-      options.minifyCSS = async function (text, type) {
+      options.minifyCSS = async function (/** @type {string} */ text, /** @type {string} */ type) {
         // Fast path: Nothing to minify
         if (!text || !text.trim()) {
           return text;
@@ -114,7 +118,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           text = await replaceAsync(
             text,
             /(url\s*\(\s*)(?:"([^"]*)"|'([^']*)'|([^\s)]+))(\s*\))/ig,
-            async function (match, prefix, dq, sq, unq, suffix) {
+            async function (/** @type {string} */ match, /** @type {string} */ prefix, /** @type {string | undefined} */ dq, /** @type {string | undefined} */ sq, /** @type {string | undefined} */ unq, /** @type {string} */ suffix) {
               const quote = dq != null ? '"' : (sq != null ? "'" : '');
               const url = dq ?? sq ?? unq ?? '';
               try {
@@ -139,7 +143,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           : (inputCSS + '|' + type + '|' + cssSig);
 
         try {
-          const cached = cssMinifyCache.get(cssKey);
+          const cached = cssCache.get(cssKey);
           if (cached) {
             // Support both resolved values and in-flight promises
             return await cached;
@@ -148,7 +152,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           // In-flight promise caching: Prevent duplicate concurrent minifications
           // of the same CSS content (same pattern as JS minification)
           const inFlight = (async () => {
-            const transformCSS = await getLightningCSS();
+            const transformCSS = await cssLoader();
             // Note: `Buffer.from()` is required—Lightning CSS API expects Uint8Array
             const result = transformCSS({
               filename: 'input.css',
@@ -175,12 +179,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             return (text.trim() && !outputCSS.trim() && (looksLikeTemplate || hasUID)) ? text : outputCSS;
           })();
 
-          cssMinifyCache.set(cssKey, inFlight);
+          cssCache.set(cssKey, inFlight);
           const resolved = await inFlight;
-          cssMinifyCache.set(cssKey, resolved);
+          cssCache.set(cssKey, resolved);
           return resolved;
         } catch (err) {
-          cssMinifyCache.delete(cssKey);
+          cssCache.delete(cssKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -189,9 +193,14 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         }
       };
     } else if (key === 'minifyJS' && typeof option !== 'function') {
-      if (!option) {
+      if (!option || !getTerser || !getSwc || !jsMinifyCache) {
         return;
       }
+
+      // Capture to preserve TypeScript narrowing across the async closure boundary below
+      const loadTerser = getTerser;
+      const loadSwc = getSwc;
+      const jsCache = jsMinifyCache;
 
       // Parse configuration
       const config = typeof option === 'object' ? option : {};
@@ -227,7 +236,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         cont: !!options.continueOnMinifyError
       });
 
-      options.minifyJS = async function (text, inline, isModule) {
+      options.minifyJS = async function (/** @type {string} */ text, /** @type {boolean} */ inline, /** @type {boolean} */ isModule) {
         const start = text.match(/^\s*<!--.*/);
         const code = start ? text.slice(start[0].length).replace(/\n\s*-->\s*$/, '') : text;
 
@@ -249,7 +258,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
             + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
-          const cached = jsMinifyCache.get(jsKey);
+          const cached = jsCache.get(jsKey);
           if (cached) {
             return await cached;
           }
@@ -266,11 +275,11 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                 },
                 ...(isModule ? { module: true } : {}) // Overrides user options: module detection takes precedence for `<script type=module>`
               };
-              const terser = await getTerser();
+              const terser = await loadTerser();
               const result = await terser(code, terserCallOptions);
               return result.code.replace(RE_TRAILING_SEMICOLON, '');
             } else if (useEngine === 'swc') {
-              const swc = await getSwc();
+              const swc = await loadSwc();
               // `swc.minify()` takes compress and mangle directly as options
               const result = await swc.minify(code, {
                 compress: true,
@@ -283,12 +292,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             throw new Error(`Unknown JS minifier engine: ${useEngine}`);
           })();
 
-          jsMinifyCache.set(jsKey, inFlight);
+          jsCache.set(jsKey, inFlight);
           const resolved = await inFlight;
-          jsMinifyCache.set(jsKey, resolved);
+          jsCache.set(jsKey, resolved);
           return resolved;
         } catch (err) {
-          if (jsKey) jsMinifyCache.delete(jsKey);
+          if (jsKey) jsCache.delete(jsKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -314,7 +323,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       // Create instance-specific cache (results depend on site configuration)
       const instanceCache = new LRU(500);
 
-      options.minifyURLs = function (text) {
+      options.minifyURLs = function (/** @type {string} */ text) {
         // Fast-path: Skip if text doesn’t look like a URL that needs processing
         // Only process if contains URL-like characters (`/`, `:`, `#`, `?`) or spaces that need encoding
         if (!/[/:?#\s]/.test(text)) {
@@ -341,9 +350,13 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         }
       };
     } else if (key === 'minifySVG' && typeof option !== 'function') {
-      if (!option) {
+      if (!option || !getSvgo || !svgMinifyCache) {
         return;
       }
+
+      // Capture to preserve TypeScript narrowing across the async closure boundary below
+      const loadSvgo = getSvgo;
+      const svgCache = svgMinifyCache;
 
       const svgoOptions = typeof option === 'object' ? option : {};
 
@@ -353,7 +366,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         cont: !!options.continueOnMinifyError
       });
 
-      options.minifySVG = async function (svgContent) {
+      options.minifySVG = async function (/** @type {string} */ svgContent) {
         if (!svgContent || !svgContent.trim()) {
           return svgContent;
         }
@@ -364,23 +377,23 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           : (svgContent + '|' + svgSig);
 
         try {
-          const cached = svgMinifyCache.get(svgKey);
+          const cached = svgCache.get(svgKey);
           if (cached) {
             return await cached;
           }
 
           const inFlight = (async () => {
-            const optimize = await getSvgo();
+            const optimize = await loadSvgo();
             const result = optimize(svgContent, svgoOptions);
             return result.data;
           })();
 
-          svgMinifyCache.set(svgKey, inFlight);
+          svgCache.set(svgKey, inFlight);
           const resolved = await inFlight;
-          svgMinifyCache.set(svgKey, resolved);
+          svgCache.set(svgKey, resolved);
           return resolved;
         } catch (err) {
-          svgMinifyCache.delete(svgKey);
+          svgCache.delete(svgKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -56,7 +56,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
   // Helper for nested arrays (e.g., `customAttrSurround: [[start, end], …]`)
   const parseNestedRegExpArray = (/** @type {unknown} */ arr) => {
-    if (!Array.isArray(arr)) return arr;
+    if (!Array.isArray(arr)) return [];
     return arr.map(item => {
       // If item is an array (a pair), recursively convert each element
       if (Array.isArray(item)) {
@@ -144,7 +144,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
         try {
           const cached = cssCache.get(cssKey);
-          if (cached) {
+          if (cached !== undefined) {
             // Support both resolved values and in-flight promises
             return await cached;
           }
@@ -259,7 +259,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
           const cached = jsCache.get(jsKey);
-          if (cached) {
+          if (cached !== undefined) {
             return await cached;
           }
 
@@ -378,7 +378,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
         try {
           const cached = svgCache.get(svgKey);
-          if (cached) {
+          if (cached !== undefined) {
             return await cached;
           }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,13 +1,17 @@
 // Stringify for options signatures (sorted keys, shallow, nested objects)
 
+/**
+ * @param {unknown} obj
+ * @returns {string}
+ */
 function stableStringify(obj) {
   if (obj == null || typeof obj !== 'object') return JSON.stringify(obj);
   if (Array.isArray(obj)) return '[' + obj.map(stableStringify).join(',') + ']';
   const keys = Object.keys(obj).sort();
   let out = '{';
   for (let i = 0; i < keys.length; i++) {
-    const k = keys[i];
-    out += JSON.stringify(k) + ':' + stableStringify(obj[k]) + (i < keys.length - 1 ? ',' : '');
+    const k = keys[i] ?? '';
+    out += JSON.stringify(k) + ':' + stableStringify(/** @type {Record<string, unknown>} */ (obj)[k]) + (i < keys.length - 1 ? ',' : '');
   }
   return out + '}';
 }
@@ -17,8 +21,10 @@ function stableStringify(obj) {
 class LRU {
   constructor(limit = 200) {
     this.limit = limit;
+    /** @type {Map<string, unknown>} */
     this.map = new Map();
   }
+  /** @param {string} key */
   get(key) {
     if (this.map.has(key)) {
       const v = this.map.get(key);
@@ -28,19 +34,25 @@ class LRU {
     }
     return undefined;
   }
+  /**
+   * @param {string} key
+   * @param {unknown} value
+   */
   set(key, value) {
     if (this.map.has(key)) this.map.delete(key);
     this.map.set(key, value);
     if (this.map.size > this.limit) {
       const first = this.map.keys().next().value;
-      this.map.delete(first);
+      if (first !== undefined) this.map.delete(first);
     }
   }
+  /** @param {string} key */
   delete(key) { this.map.delete(key); }
 }
 
 // FNV-1a 32-bit hash for large-input cache keys
 
+/** @param {string} str */
 function hashContent(str) {
   let hash = 2166136261;
   for (let i = 0; i < str.length; i++) {
@@ -52,6 +64,7 @@ function hashContent(str) {
 
 // Unique ID generator
 
+/** @param {string} value */
 function uniqueId(value) {
   let id;
   do {
@@ -62,14 +75,17 @@ function uniqueId(value) {
 
 // Identity and transform functions
 
+/** @param {string} value */
 function identity(value) {
   return value;
 }
 
+/** @param {unknown} value */
 function isThenable(value) {
-  return value != null && typeof value === 'object' && typeof value.then === 'function';
+  return value != null && typeof value === 'object' && typeof /** @type {any} */ (value).then === 'function';
 }
 
+/** @param {string} value */
 function lowercase(value) {
   return value.toLowerCase();
 }
@@ -83,26 +99,35 @@ function lowercase(value) {
  * @param {Function} asyncFn - Async function to process each match
  * @returns {Promise<string>} Processed string
  */
+/**
+ * @param {string} str
+ * @param {RegExp} regex
+ * @param {Function} asyncFn
+ * @returns {Promise<string>}
+ */
 async function replaceAsync(str, regex, asyncFn) {
+  /** @type {Promise<string>[]} */
   const promises = [];
 
-  str.replace(regex, (match, ...args) => {
+  str.replace(regex, /** @returns {string} */ (match, ...args) => {
     const promise = asyncFn(match, ...args);
     promises.push(promise);
+    return match;
   });
 
   const data = await Promise.all(promises);
-  return str.replace(regex, () => data.shift());
+  return str.replace(regex, () => data.shift() ?? '');
 }
 
 // String patterns to RegExp conversion (for JSON config support)
 
+/** @param {string | RegExp} value */
 function parseRegExp(value) {
   if (typeof value === 'string') {
     if (!value) return undefined; // Empty string = not configured
     const match = value.match(/^\/(.+)\/([dgimsuvy]*)$/);
     if (match) {
-      return new RegExp(match[1], match[2]);
+      return new RegExp(match[1] ?? '', match[2] ?? '');
     }
     return new RegExp(value);
   }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -99,12 +99,6 @@ function lowercase(value) {
  * @param {Function} asyncFn - Async function to process each match
  * @returns {Promise<string>} Processed string
  */
-/**
- * @param {string} str
- * @param {RegExp} regex
- * @param {Function} asyncFn
- * @returns {Promise<string>}
- */
 async function replaceAsync(str, regex, asyncFn) {
   /** @type {Promise<string>[]} */
   const promises = [];

--- a/src/lib/whitespace.js
+++ b/src/lib/whitespace.js
@@ -15,6 +15,7 @@ import {
 
 // Trim whitespace
 
+/** @param {string} str */
 const trimWhitespace = str => {
   if (!str) return str;
   // Fast path: If no whitespace at start or end, return early
@@ -26,6 +27,7 @@ const trimWhitespace = str => {
 
 // Collapse all whitespace
 
+/** @param {string} str */
 function collapseWhitespaceAll(str) {
   if (!str) return str;
   // Fast path: If there are no common whitespace characters, return early
@@ -33,7 +35,7 @@ function collapseWhitespaceAll(str) {
     return str;
   }
   // No-break space is specifically handled inside the replacer function here:
-  return str.replace(RE_ALL_WS_NBSP, function (spaces) {
+  return str.replace(RE_ALL_WS_NBSP, function (/** @param {string} spaces */ spaces) {
     // Preserve standalone tabs
     if (spaces === '\t') return '\t';
     // Fast path: No no-break space, common case—just collapse to single space
@@ -46,7 +48,14 @@ function collapseWhitespaceAll(str) {
 
 // Collapse whitespace with options
 
-function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
+/**
+ * @param {string} str
+ * @param {{preserveLineBreaks?: boolean | undefined, conservativeCollapse?: boolean | undefined}} options
+ * @param {boolean} trimLeft
+ * @param {boolean} trimRight
+ * @param {boolean} [collapseAll]
+ */
+function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll = false) {
   let lineBreakBefore = ''; let lineBreakAfter = '';
 
   if (!str) return str;
@@ -66,7 +75,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
     // (avoids polynomial backtracking with end-anchored lazy quantifiers)
     const WS_CHARS = ' \n\r\t\f';
     let leadEnd = 0;
-    while (leadEnd < str.length && WS_CHARS.includes(str[leadEnd])) {
+    while (leadEnd < str.length && WS_CHARS.includes(str.charAt(leadEnd))) {
       leadEnd++;
     }
     if (leadEnd > 0) {
@@ -77,7 +86,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
       }
     }
     let trailStart = str.length;
-    while (trailStart > 0 && WS_CHARS.includes(str[trailStart - 1])) {
+    while (trailStart > 0 && WS_CHARS.includes(str.charAt(trailStart - 1))) {
       trailStart--;
     }
     if (trailStart < str.length) {
@@ -91,7 +100,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
 
   if (trimLeft) {
     // No-break space is specifically handled inside the replacer function
-    str = str.replace(/^[ \n\r\t\f\xA0]+/, function (spaces) {
+    str = str.replace(/^[ \n\r\t\f\xA0]+/, function (/** @type {string} */ spaces) {
       const conservative = !lineBreakBefore && options.conservativeCollapse;
       if (conservative && spaces === '\t') {
         return '\t';
@@ -104,7 +113,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
     // Find trailing whitespace boundary manually (avoids polynomial backtracking
     // with `/[ \n\r\t\f\xA0]+$/` on strings with long internal whitespace runs)
     let end = str.length;
-    while (end > 0 && ' \n\r\t\f\xA0'.includes(str[end - 1])) {
+    while (end > 0 && ' \n\r\t\f\xA0'.includes(str.charAt(end - 1))) {
       end--;
     }
     if (end < str.length) {
@@ -135,14 +144,24 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
 
 // Collapse whitespace smartly based on surrounding tags
 
+/**
+ * @param {string} str
+ * @param {string} prevTag
+ * @param {string} nextTag
+ * @param {Array<{name: string, value?: string}>} prevAttrs
+ * @param {Array<{name: string, value?: string}>} nextAttrs
+ * @param {{preserveLineBreaks?: boolean, conservativeCollapse?: boolean, collapseInlineTagWhitespace?: boolean}} options
+ * @param {Set<string>} inlineElements
+ * @param {Set<string>} inlineTextSet
+ */
 function collapseWhitespaceSmart(str, prevTag, nextTag, prevAttrs, nextAttrs, options, inlineElements, inlineTextSet) {
   const prevTagName = prevTag && (prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag);
   const nextTagName = nextTag && (nextTag.charAt(0) === '/' ? nextTag.slice(1) : nextTag);
 
   // Helper: Check if an input element has `type="hidden"`
-  const isHiddenInput = (tagName, attrs) => {
+  const isHiddenInput = (/** @type {string} */ tagName, /** @type {Array<{name: string, value?: string}>} */ attrs) => {
     if (tagName !== 'input' || !attrs || !attrs.length) return false;
-    const typeAttr = attrs.find(attr => attr.name === 'type');
+    const typeAttr = attrs.find((/** @type {{name: string, value?: string}} */ attr) => attr.name === 'type');
     return typeAttr && typeAttr.value === 'hidden';
   };
 
@@ -206,7 +225,7 @@ function collapseWhitespaceSmart(str, prevTag, nextTag, prevAttrs, nextAttrs, op
     }
   }
 
-  return collapseWhitespace(str, options, trimLeft, trimRight, prevTag && nextTag);
+  return collapseWhitespace(str, options, Boolean(trimLeft), Boolean(trimRight), Boolean(prevTag && nextTag));
 }
 
 // Collapse/trim whitespace for given tag
@@ -214,10 +233,12 @@ function collapseWhitespaceSmart(str, prevTag, nextTag, prevAttrs, nextAttrs, op
 const noCollapseWhitespaceTags = new Set(['script', 'style', 'pre', 'textarea']);
 const noTrimWhitespaceTags = new Set(['pre', 'textarea']);
 
+/** @param {string} tag */
 function canCollapseWhitespace(tag) {
   return !noCollapseWhitespaceTags.has(tag);
 }
 
+/** @param {string} tag */
 function canTrimWhitespace(tag) {
   return !noTrimWhitespaceTags.has(tag);
 }

--- a/src/lib/whitespace.js
+++ b/src/lib/whitespace.js
@@ -1,5 +1,3 @@
-// Imports
-
 import {
   RE_WS_START,
   RE_WS_END,

--- a/src/presets.js
+++ b/src/presets.js
@@ -47,7 +47,7 @@ export const presets = {
 export function getPreset(name) {
   if (!name) return null;
   const normalizedName = name.toLowerCase();
-  return presets[normalizedName] || null;
+  return /** @type {Record<string, object>} */ (presets)[normalizedName] || null;
 }
 
 /**

--- a/src/tokenchain.js
+++ b/src/tokenchain.js
@@ -1,17 +1,29 @@
 class Sorter {
+  constructor() {
+    /** @type {string[]} */
+    this.keys = [];
+    /** @type {Map<string, Sorter>} */
+    this.sorterMap = new Map();
+  }
+
+  /**
+   * @param {string[]} tokens
+   * @param {number} fromIndex
+   * @returns {string[]}
+   */
   sort(tokens, fromIndex = 0) {
-    for (let i = 0, len = this.keys.length; i < len; i++) {
-      const token = this.keys[i];
+    for (const token of this.keys) {
 
       // Single pass: Count matches and collect non-matches
       let matchCount = 0;
       const others = [];
 
       for (let j = fromIndex; j < tokens.length; j++) {
-        if (tokens[j] === token) {
+        const t = /** @type {string} */ (tokens[j]);
+        if (t === token) {
           matchCount++;
         } else {
-          others.push(tokens[j]);
+          others.push(t);
         }
       }
 
@@ -21,12 +33,12 @@ class Sorter {
         for (let j = 0; j < matchCount; j++) {
           tokens[writeIdx++] = token;
         }
-        for (let j = 0; j < others.length; j++) {
-          tokens[writeIdx++] = others[j];
+        for (const other of others) {
+          tokens[writeIdx++] = other;
         }
 
         const newFromIndex = fromIndex + matchCount;
-        return this.sorterMap.get(token).sort(tokens, newFromIndex);
+        return this.sorterMap.get(token)?.sort(tokens, newFromIndex) ?? tokens;
       }
     }
     return tokens;
@@ -35,22 +47,22 @@ class Sorter {
 
 class TokenChain {
   constructor() {
-    // Use map instead of object properties for better performance
+    /** @type {Map<string, {arrays: string[][], processed: number}>} */
     this.map = new Map();
   }
 
+  /** @param {string[]} tokens */
   add(tokens) {
     tokens.forEach((token) => {
       if (!this.map.has(token)) {
         this.map.set(token, { arrays: [], processed: 0 });
       }
-      this.map.get(token).arrays.push(tokens);
+      this.map.get(token)?.arrays.push(tokens);
     });
   }
 
   createSorter() {
     const sorter = new Sorter();
-    sorter.sorterMap = new Map();
 
     // Convert map entries to array and sort by frequency (descending), then alphabetically
     const entries = Array.from(this.map.entries()).sort((a, b) => {
@@ -63,18 +75,17 @@ class TokenChain {
       return a[0].localeCompare(b[0]);
     });
 
-    sorter.keys = [];
-
     entries.forEach(([token, data]) => {
       if (data.processed < data.arrays.length) {
         const chain = new TokenChain();
 
         data.arrays.forEach((tokens) => {
           // Build new array without the current token instead of splicing
+          /** @type {string[]} */
           const filtered = [];
-          for (let i = 0; i < tokens.length; i++) {
-            if (tokens[i] !== token) {
-              filtered.push(tokens[i]);
+          for (const t of tokens) {
+            if (t !== token) {
+              filtered.push(t);
             }
           }
 

--- a/src/tokenchain.js
+++ b/src/tokenchain.js
@@ -54,10 +54,12 @@ class TokenChain {
   /** @param {string[]} tokens */
   add(tokens) {
     tokens.forEach((token) => {
-      if (!this.map.has(token)) {
-        this.map.set(token, { arrays: [], processed: 0 });
+      let entry = this.map.get(token);
+      if (!entry) {
+        entry = { arrays: [], processed: 0 };
+        this.map.set(token, entry);
       }
-      this.map.get(token)?.arrays.push(tokens);
+      entry.arrays.push(tokens);
     });
   }
 

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -2397,6 +2397,8 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, {}), input);
     assert.strictEqual(await minify(input, { collapseWhitespace: true }), output);
     assert.strictEqual(await minify(input, { collapseWhitespace: true, ignoreCustomFragments: [] }), output);
+    // A bare (non-array) RegExp is treated as an empty fragment list, same as `[]`
+    assert.strictEqual(await minify(input, { collapseWhitespace: true, ignoreCustomFragments: /\{\{[^}]*\}\}/ }), output);
 
     output = '{{ if foo? }} <div class="bar">…</div> {{ end \n}}';
     assert.strictEqual(await minify(input, { collapseWhitespace: true, ignoreCustomFragments: reFragments }), output);
@@ -3657,6 +3659,10 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, { removeComments: true }), input);
     assert.strictEqual(await minify(input, { removeComments: true, ignoreCustomComments: false }), '');
     assert.strictEqual(await minify(input, { removeComments: true, ignoreCustomComments: [] }), '');
+
+    // A bare (non-array) RegExp is treated as an empty ignore list—the comment is removed
+    input = '<!-- foo -->';
+    assert.strictEqual(await minify(input, { removeComments: true, ignoreCustomComments: /foo/ }), '');
   });
 
   test('`processScripts`', async () => {
@@ -3687,6 +3693,16 @@ describe('HTML', () => {
     input = '<script type="application/json; charset=utf-8">{"foo": "bar"}</script>';
     result = await minify(input, { collapseWhitespace: true });
     assert.ok(result.includes('{"foo":"bar"}'), 'JSON detection should strip parameters');
+
+    // `<script type>` with no value: `rawValue` is undefined, should not match `processScripts`
+    assert.strictEqual(
+      await minify('<script type="text/ng-template"><div> test </div></script>', { collapseWhitespace: true, processScripts: ['text/ng-template'] }),
+      '<script type="text/ng-template"><div>test</div></script>'
+    );
+    assert.strictEqual(
+      await minify('<script type><div> test </div></script>', { collapseWhitespace: true, processScripts: ['text/ng-template'] }),
+      '<script type><div> test </div></script>'
+    );
   });
 
   test('`htmlmin:ignore`', async () => {
@@ -5439,6 +5455,11 @@ describe('HTML', () => {
     const html2 = '<div [class="test"]>content</div>';
     const result2 = await minify(html2, jsonConfig);
     assert.strictEqual(result2, '<div [class=test]>content</div>');
+  });
+
+  test('`customAttrSurround` with non-array value degrades gracefully', async () => {
+    // A non-array value is treated as empty (no custom surrounds) and should not throw
+    await assert.doesNotReject(minify('<div foo="bar"></div>', { customAttrSurround: /foo/ }));
   });
 
   test('`customAttrSurround` with complex template patterns', async () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -19,7 +19,7 @@ async function testBasicMinify() {
   const result: string = await minify(html);
 
   // Should accept options
-  const result2: string = await minify(html, {
+  await minify(html, {
     collapseWhitespace: true,
     removeComments: true,
   });
@@ -73,14 +73,14 @@ async function testMinifyCSSOptions() {
 
   // Function
   await minify(html, {
-    minifyCSS: (text: string, type?: string) => {
+    minifyCSS: (text: string, _type?: string) => {
       return text.replace(/\s+/g, ' ');
     },
   });
 
   // Async function
   await minify(html, {
-    minifyCSS: async (text: string, type?: string) => {
+    minifyCSS: async (text: string, _type?: string) => {
       return Promise.resolve(text.trim());
     },
   });
@@ -103,14 +103,14 @@ async function testMinifyJSOptions() {
 
   // Function
   await minify(html, {
-    minifyJS: (text: string, inline?: boolean) => {
+    minifyJS: (text: string, _inline?: boolean) => {
       return text.replace(/\s+/g, ' ');
     },
   });
 
   // Async function
   await minify(html, {
-    minifyJS: async (text: string, inline?: boolean) => {
+    minifyJS: async (text: string, _inline?: boolean) => {
       return Promise.resolve(text.trim());
     },
   });
@@ -185,16 +185,16 @@ async function testFunctionOptions() {
       console.log(message);
     },
     name: (name: string) => name.toLowerCase(),
-    canCollapseWhitespace: (tag, attrs, canCollapseWhitespace) => {
+    canCollapseWhitespace: (tag, _attrs, _canCollapseWhitespace) => {
       return tag !== 'pre';
     },
-    canTrimWhitespace: (tag, attrs, canTrimWhitespace) => {
+    canTrimWhitespace: (tag, _attrs, _canTrimWhitespace) => {
       return tag !== 'textarea';
     },
-    removeEmptyAttributes: (attrName: string, tag: string) => {
+    removeEmptyAttributes: (attrName: string, _tag: string) => {
       return attrName !== 'alt';
     },
-    sortAttributes: (tag: string, attrs: HTMLAttribute[]) => {
+    sortAttributes: (_tag: string, attrs: HTMLAttribute[]) => {
       attrs.sort((a, b) => a.name.localeCompare(b.name));
     },
     sortClassNames: (value: string) => {
@@ -273,7 +273,7 @@ async function testTypeInference() {
   });
 
   // Result should be inferred as string
-  const length: number = result.length;
+  void result.length;
 
   return result;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,34 @@
+{
+  // https://aka.ms/tsconfig
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    // Environment settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "nodenext",
+    "target": "esnext",
+
+    // JavaScript support
+    "allowJs": true,
+
+    // Recommended options
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "erasableSyntaxOnly": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Strict type-checking
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Additional checks
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   // https://aka.ms/tsconfig
   "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.base.json",
   "include": [
     "./src/htmlminifier.js"
   ],
@@ -9,42 +10,15 @@
     "rootDir": "./src",
     "outDir": "./dist/types",
 
-    // Environment settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
-    "target": "esnext",
-    "types": [],
+    // Node type definitions for `process`, `Buffer`, etc.
+    "types": ["node"],
 
     // JavaScript support
-    "allowJs": true,
-    // "checkJs": true, // @@ Enable and fix errors
+    "checkJs": true,
 
     // Outputs
     "emitDeclarationOnly": true,
     "declaration": true,
-    "declarationMap": true,
-    "listEmittedFiles": true,
-
-    // Recommended options
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "erasableSyntaxOnly": true,
-    "forceConsistentCasingInFileNames": true,
-
-    // Stricter type-checking options
-    // "strict": true,
-    // "noUncheckedIndexedAccess": true,
-    // "exactOptionalPropertyTypes": true,
-
-    // Style options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
+    "declarationMap": true
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,33 +1,15 @@
 {
   // https://aka.ms/tsconfig
   "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.base.json",
   "include": [
     "./tests/**/*.ts"
   ],
   "compilerOptions": {
-    // Environment settings
-    "module": "nodenext",
-    "target": "esnext",
+    // No Node types—tests don’t use `process`/`Buffer` directly
     "types": [],
 
-    // JavaScript support
-    "allowJs": true,
-
     // Don’t emit files, just check types
-    "noEmit": true,
-
-    // Recommended options
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "erasableSyntaxOnly": true,
-    "forceConsistentCasingInFileNames": true,
-
-    // Stricter type-checking options
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true
+    "noEmit": true
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent skips when custom-comment/fragment ignore options are misconfigured; improved null-safety and robustness across parsing, attributes, minification, and whitespace handling.
  * Standardized an error message for unexpected minify results.

* **Chores**
  * Released v6.2.9 and bumped dev dependency versions.
  * Enabled stricter TypeScript/JSDoc checking with a shared base config.

* **Tests**
  * Expanded tests for comment/fragment ignore behavior, script-processing semantics, and updated type-check tests.

* **Documentation**
  * Added/updated CHANGELOG entry for v6.2.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->