### PR TITLE
Add explicit `-i`/`--input` flag, improve input DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.10] - 2026-06-07
+
+### Added
+
+* Added `-i`/`--input <file>` flag as an explicit alternative to passing the input file as a positional argument, creating a symmetrical pair with `-o`/`--output` (and mirroring the `-I`/`-O` convention for directories)
+
+### Changed
+
+* Improved the error message when `-I`/`--input-dir` is given a file path instead of a directory—it now includes a suggestion to use `-i`/`-o` instead
+
 ## [6.2.9] - 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Use `npx html-minifier-next --help` to check all available options:
 | `--input-dir <dir>`, `-I <dir>` | Specify an input directory | `--input-dir=src` |
 | `--ignore-dir <patterns>`, `-X <patterns>` | Exclude directories—relative to input directory—from processing (comma-separated, overrides config file setting) | `--ignore-dir=libs`, `--ignore-dir=libs,vendor,node_modules` |
 | `--output-dir <dir>`, `-O <dir>` | Specify an output directory | `--output-dir=dist` |
-| `--output <file>`, `-o <file>` | Specify output file (reads from file arguments or STDIN) | File to file: `npx html-minifier-next input.html -o output.html`<br>Pipe to file: `cat input.html \| npx html-minifier-next -o output.html`<br>File to STDOUT: `npx html-minifier-next input.html` |
+| `--input <file>`, `-i <file>` | Specify input file (alternative to positional argument; pair with `--output` for file output) | `npx html-minifier-next -i input.html -o output.html` |
+| `--output <file>`, `-o <file>` | Specify output file (reads from `--input` file argument or STDIN; outputs to STDOUT if not specified) | File to file: `npx html-minifier-next input.html -o output.html`<br>File to file (explicit): `npx html-minifier-next -i input.html -o output.html`<br>Pipe to file: `cat input.html \| npx html-minifier-next -o output.html`<br>File to STDOUT: `npx html-minifier-next input.html` |
 | `--file-ext <extensions>`, `-f <extensions>` | Specify file extension(s) to process (comma-separated, overrides config file setting); defaults to `html,htm,shtml,shtm`; use `*` for all files | `--file-ext=html,php`, `--file-ext='*'` |
 | `--preset <name>`, `-p <name>` | Use a preset configuration (conservative or comprehensive) | `--preset=conservative` |
 | `--config-file <file>`, `-c <file>` | Use a configuration file | `--config-file=html-minifier.json` |

--- a/cli.js
+++ b/cli.js
@@ -171,7 +171,8 @@ mainOptionKeys.forEach(function (key) {
     program.option(cliFlag, description, parser);
   }
 });
-program.option('-o --output <file>', 'Specify output file (reads from file arguments or STDIN; outputs to STDOUT if not specified)');
+program.option('-i --input <file>', 'Specify input file (alternative to positional argument; pair with `--output` for output)');
+program.option('-o --output <file>', 'Specify output file (reads from `--input` file argument or STDIN; outputs to STDOUT if not specified)');
 program.option('-v --verbose', 'Show detailed processing information');
 program.option('-d --dry', 'Dry run: Process and report statistics without writing output');
 program.addHelpText('after', '\nBoolean options support a `--no-<flag>` form to disable them, overriding a preset or config file (e.g., `--preset=comprehensive --no-collapse-whitespace`).');
@@ -318,7 +319,11 @@ program.helpOption('-h, --help', 'Display help for command');
     }
   }
 
-  // Defer reading files—multi-file mode will process per-file later
+  // If `--input` was specified, treat it as a positional file argument
+  if (programOptions.input) {
+    capturedFiles.unshift(programOptions.input);
+    filesProvided = true;
+  }
 
   // Handle zero config mode (standalone in-place minification of the current folder)
   if (programOptions.zero) {
@@ -735,7 +740,7 @@ program.helpOption('-h, --help', 'Display help for command');
 
   if (inputDir || outputDir) {
     if (!inputDir) {
-      fatal('The option `output-dir` needs to be used with the option `input-dir`—if you are working with a single file, use `-o`');
+      fatal('The option `output-dir` needs to be used with the option `input-dir`—if you are working with a single file, use `--input`/`--output`');
     } else if (!outputDir) {
       fatal('You need to specify where to write the output files with the option `--output-dir`');
     }
@@ -780,7 +785,7 @@ program.helpOption('-h, --help', 'Display help for command');
       try {
         const stat = await fs.promises.stat(inputDir);
         if (!stat.isDirectory()) {
-          fatal(inputDir + ' is not a directory');
+          fatal(`${inputDir} is not a directory—to minify a single file, use \`--input\`/\`--output\`: html-minifier-next [options] -i ${inputDir} -o <output-file>`);
         }
       } catch (err) {
         fatal('Cannot read directory ' + inputDir + '\n' + err.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.9",
+  "version": "6.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.9",
+      "version": "6.2.10",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -98,5 +98,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.9"
+  "version": "6.2.10"
 }

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -103,7 +103,7 @@ describe('CLI', () => {
       '--output-dir=./'
     ];
 
-    assert.throws(() => execCli(cliArguments), /The option `output-dir` needs to be used with the option `input-dir`—if you are working with a single file, use `-o`/);
+    assert.throws(() => execCli(cliArguments), /The option `output-dir` needs to be used with the option `input-dir`—if you are working with a single file, use `--input`\/`--output`/);
   });
 
   test('Should throw error for invalid max-line-length value', () => {
@@ -741,6 +741,51 @@ describe('CLI', () => {
     // Should output to STDOUT
     assert.ok(result.length > 0);
     assert.ok(result.includes('<!DOCTYPE html>'));
+  });
+
+  // `-i` flag tests
+  test('Should minify file to STDOUT with `-i` flag', () => {
+    const result = execCli([
+      '-i', 'default.html',
+      '--collapse-whitespace'
+    ]);
+
+    assert.ok(result.length > 0);
+    assert.ok(result.includes('<!DOCTYPE html>'));
+  });
+
+  test('Should minify file to file with `-i`/`-o` flags', async () => {
+    fs.mkdirSync(path.resolve(fixturesDir, 'tmp'), { recursive: true });
+
+    execCli([
+      '-i', 'default.html',
+      '-o', 'tmp/input-flag-output.html',
+      '--collapse-whitespace'
+    ]);
+
+    assert.strictEqual(existsFixture('tmp/input-flag-output.html'), true);
+
+    const output = await readFixture('tmp/input-flag-output.html');
+    assert.ok(output.length > 0);
+    assert.ok(output.includes('<!DOCTYPE html>'));
+  });
+
+  test('Should produce the same output with `-i` as with a positional argument', async () => {
+    const viaPositional = execCli(['default.html', '--collapse-whitespace']);
+    const viaFlag = execCli(['-i', 'default.html', '--collapse-whitespace']);
+
+    assert.strictEqual(viaPositional, viaFlag);
+  });
+
+  test('Should throw error if file passed to `-i` is not found', () => {
+    assert.throws(() => execCli(['-i', 'no-file.html']), /no such file/);
+  });
+
+  test('Should show helpful error when `-I` receives a file instead of a directory', () => {
+    assert.throws(
+      () => execCli(['-I', 'default.html', '-O', './tmp']),
+      /is not a directory.*-i.*-o/
+    );
   });
 
   // Error handling tests for dry run


### PR DESCRIPTION
Resolves #289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `-i`/`--input <file>` CLI flag as an alternative to positional file arguments for single-file minification operations in combination with `-o`/`--output`.

* **Documentation**
  * Updated README and error messages to reflect the new `-i`/`--input` option and provide clearer guidance for file-to-file minification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->