### PR TITLE
Warn on (specific) non-HTML input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.11] - 2026-06-09
+
+### Added
+
+* Added a warning when a file with a non-HTML extension (`.css`, `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.svg`) is passed as input—HMN processes CSS, JavaScript, and SVG only when embedded in HTML, so standalone non-HTML files may produce incomplete or broken output
+
 ## [6.2.10] - 2026-06-07
 
 ### Added

--- a/cli.js
+++ b/cli.js
@@ -58,7 +58,8 @@ import { optionDefinitions } from './src/lib/option-definitions.js';
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
 
-const DEFAULT_FILE_EXTENSIONS = ['html', 'htm', 'shtml', 'shtm'];
+const EXTENSIONS_DEFAULT = ['html', 'htm', 'shtml', 'shtm'];
+const EXTENSIONS_NON_HTML = new Set(['css', 'js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'svg']);
 
 const MARK_ERROR = process.stderr.isTTY ? '\x1b[31m' : '';
 const MARK_SUCCESS = process.stderr.isTTY ? '\x1b[32m' : '';
@@ -362,7 +363,7 @@ program.helpOption('-h, --help', 'Display help for command');
       programOptions.preset = 'comprehensive';
 
       const inputDirResolved = await fs.promises.realpath(cwd).catch(() => cwd);
-      const extensions = DEFAULT_FILE_EXTENSIONS;
+      const extensions = EXTENSIONS_DEFAULT;
       const ignorePatterns = ['node_modules'];
 
       const showProgress = process.stderr.isTTY;
@@ -732,7 +733,7 @@ program.helpOption('-h, --help', 'Display help for command');
 
   // Resolve file extensions: CLI argument > config file > defaults
   const hasCliFileExt = program.getOptionValueSource('fileExt') === 'cli';
-  const resolvedFileExt = hasCliFileExt ? (fileExt || '*') : (config.fileExt || DEFAULT_FILE_EXTENSIONS);
+  const resolvedFileExt = hasCliFileExt ? (fileExt || '*') : (config.fileExt || EXTENSIONS_DEFAULT);
 
   // Resolve ignore patterns: CLI argument takes priority over config file
   const hasCliIgnoreDir = program.getOptionValueSource('ignoreDir') === 'cli';
@@ -743,6 +744,16 @@ program.helpOption('-h, --help', 'Display help for command');
       fatal('The option `output-dir` needs to be used with the option `input-dir`—if you are working with a single file, use `--input`/`--output`');
     } else if (!outputDir) {
       fatal('You need to specify where to write the output files with the option `--output-dir`');
+    }
+
+    {
+      const extList = Array.isArray(resolvedFileExt) ? resolvedFileExt : parseFileExtensions(String(resolvedFileExt || ''));
+      const isWildcard = extList.includes('*');
+      const nonHtmlExts = isWildcard ? [] : extList.filter(e => EXTENSIONS_NON_HTML.has(e));
+      if (isWildcard || nonHtmlExts.length > 0) {
+        const label = isWildcard ? 'all file types' : nonHtmlExts.map(e => `.${e}`).join(', ');
+        console.error(`${MARK_WARNING}Warning: Processing ${label}—HTML Minifier Next processes CSS, JavaScript, and SVG only when embedded in HTML. Non-HTML files may produce incomplete or broken output.${MARK_RESET}`);
+      }
     }
 
     await (async () => {
@@ -838,6 +849,13 @@ program.helpOption('-h, --help', 'Display help for command');
     // Show config info if verbose/dry
     if (programOptions.verbose || programOptions.dry) {
       getActiveOptionsDisplay(minifierOptions);
+    }
+
+    for (const file of capturedFiles) {
+      const ext = path.extname(file).replace(/^\./, '').toLowerCase();
+      if (EXTENSIONS_NON_HTML.has(ext)) {
+        console.error(`${MARK_WARNING}Warning: “${path.basename(file)}” does not appear to be an HTML file—HTML Minifier Next processes CSS, JavaScript, and SVG only when embedded in HTML. The output may be incomplete or broken.${MARK_RESET}`);
+      }
     }
 
     const concurrency = Math.max(1, Math.min(os.cpus().length || 4, 8));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "6.2.10",
+      "version": "6.2.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -98,5 +98,5 @@
   },
   "type": "module",
   "types": "./dist/types/htmlminifier.d.ts",
-  "version": "6.2.10"
+  "version": "6.2.11"
 }

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -405,7 +405,8 @@ describe('CLI', () => {
       '--collapse-whitespace'
     ];
 
-    execCli(cliArguments);
+    const { stderr } = execCliWithStderr(cliArguments);
+    assert.ok(stderr.includes('Warning:'), 'Should warn when processing all file types');
 
     // Should process all files when wildcard is specified
     assert.strictEqual(existsFixture('tmp/all-files/extension.html'), true);
@@ -451,7 +452,8 @@ describe('CLI', () => {
       '--collapse-whitespace'
     ];
 
-    execCli(cliArguments);
+    const { stderr } = execCliWithStderr(cliArguments);
+    assert.ok(stderr.includes('Warning:'), 'Should warn when processing all file types');
 
     // Empty `--file-ext=` is treated as wildcard (all files)
     assert.strictEqual(existsFixture('tmp/empty-ext/extension.html'), true);
@@ -560,7 +562,8 @@ describe('CLI', () => {
       '--file-ext=' // Empty CLI argument overrides config; treated as wildcard
     ];
 
-    execCli(cliArguments);
+    const { stderr } = execCliWithStderr(cliArguments);
+    assert.ok(stderr.includes('Warning:'), 'Should warn when processing all file types');
 
     // Should process ALL files (empty `--file-ext=` is treated as wildcard)
     assert.strictEqual(existsFixture('tmp/config-empty-override/extension.html'), true);
@@ -779,6 +782,24 @@ describe('CLI', () => {
 
   test('Should throw error if file passed to `-i` is not found', () => {
     assert.throws(() => execCli(['-i', 'no-file.html']), /no such file/);
+  });
+
+  test('Should warn when a non-HTML file is passed as a positional argument', () => {
+    fs.mkdirSync(path.resolve(fixturesDir, 'tmp'), { recursive: true });
+    fs.writeFileSync(path.resolve(fixturesDir, 'tmp/test.js'), '// comment\nfunction foo() { return 1; }\n');
+
+    const { stderr } = execCliWithStderr(['tmp/test.js', '--collapse-whitespace']);
+    assert.ok(stderr.includes('Warning:'), 'Should warn for non-HTML file extension');
+    assert.ok(stderr.includes('test.js'), 'Warning should name the file');
+  });
+
+  test('Should warn when a non-HTML file is passed via `-i`', () => {
+    fs.mkdirSync(path.resolve(fixturesDir, 'tmp'), { recursive: true });
+    fs.writeFileSync(path.resolve(fixturesDir, 'tmp/test.css'), '.foo { color: red; }\n');
+
+    const { stderr } = execCliWithStderr(['-i', 'tmp/test.css', '--collapse-whitespace']);
+    assert.ok(stderr.includes('Warning:'), 'Should warn for non-HTML file extension');
+    assert.ok(stderr.includes('test.css'), 'Warning should name the file');
   });
 
   test('Should show helpful error when `-I` receives a file instead of a directory', () => {

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -788,18 +788,20 @@ describe('CLI', () => {
     fs.mkdirSync(path.resolve(fixturesDir, 'tmp'), { recursive: true });
     fs.writeFileSync(path.resolve(fixturesDir, 'tmp/test.js'), '// comment\nfunction foo() { return 1; }\n');
 
-    const { stderr } = execCliWithStderr(['tmp/test.js', '--collapse-whitespace']);
+    const { stderr, exitCode } = execCliWithStderr(['tmp/test.js', '--collapse-whitespace']);
     assert.ok(stderr.includes('Warning:'), 'Should warn for non-HTML file extension');
     assert.ok(stderr.includes('test.js'), 'Warning should name the file');
+    assert.strictEqual(exitCode, 0, 'Should still exit successfully');
   });
 
   test('Should warn when a non-HTML file is passed via `-i`', () => {
     fs.mkdirSync(path.resolve(fixturesDir, 'tmp'), { recursive: true });
     fs.writeFileSync(path.resolve(fixturesDir, 'tmp/test.css'), '.foo { color: red; }\n');
 
-    const { stderr } = execCliWithStderr(['-i', 'tmp/test.css', '--collapse-whitespace']);
+    const { stderr, exitCode } = execCliWithStderr(['-i', 'tmp/test.css', '--collapse-whitespace']);
     assert.ok(stderr.includes('Warning:'), 'Should warn for non-HTML file extension');
     assert.ok(stderr.includes('test.css'), 'Warning should name the file');
+    assert.strictEqual(exitCode, 0, 'Should still exit successfully');
   });
 
   test('Should show helpful error when `-I` receives a file instead of a directory', () => {


### PR DESCRIPTION
Resolves #289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 6.2.11

* **New Features**
  * CLI now emits a warning when non-HTML file extensions (.css, .js, .ts, .tsx, .svg) are provided as input, since these types are only reliably processed when embedded in HTML.

* **Tests**
  * Added and updated CLI tests to validate warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->