### PR TITLE
Fix and extend `*srcset` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-08
+
+### Fixed
+
+* Fixed `srcset` handling corrupting URLs that contain commas (e.g., Cloudflare Images URLs like `/cdn-cgi/image/fit=contain,width=320/…`)—image candidates are now split per the HTML spec’s `srcset` parsing algorithm instead of naively on every comma
+
+### Added
+
+* Added support for the `imagesrcset` attribute on `link` elements (as used for `rel="preload" as="image"`)—it now receives the same minification as `srcset` on `img` and `source` elements, including descriptor normalization and `minifyURLs` support
+
 ## [7.0.0] - 2026-06-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1966,6 +1966,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -4318,6 +4337,18 @@
           "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
           "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
           "dev": true
+        },
+        "conventional-commits-parser": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+          "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@simple-libs/stream-utils": "^1.2.0",
+            "meow": "^13.0.0"
+          }
         },
         "meow": {
           "version": "13.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",
@@ -1964,24 +1964,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {
@@ -4336,18 +4318,6 @@
           "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
           "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
           "dev": true
-        },
-        "conventional-commits-parser": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-          "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@simple-libs/stream-utils": "^1.2.0",
-            "meow": "^13.0.0"
-          }
         },
         "meow": {
           "version": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -91,5 +91,5 @@
     "test:watch": "node --test --watch tests/*.spec.js"
   },
   "type": "module",
-  "version": "7.0.0"
+  "version": "7.1.0"
 }

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -303,7 +303,8 @@ function isMediaQuery(tag, attrs, attrName) {
  * @param {string} tag
  */
 function isSrcset(attrName, tag) {
-  return attrName === 'srcset' && srcsetElements.has(tag);
+  return (attrName === 'srcset' && srcsetElements.has(tag)) ||
+    (attrName === 'imagesrcset' && tag === 'link');
 }
 
 /**
@@ -492,8 +493,34 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
   }
 
   if (isSrcset(attrName, tag)) {
-    // https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset
-    const candidates = trimWhitespace(attrValue).split(/\s*,\s*/);
+    // Split into image candidate strings following the spec parsing algorithm
+    // (https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute);
+    // a naive split on commas would corrupt URLs that contain commas
+    const value = trimWhitespace(attrValue);
+    /** @type {string[]} */
+    const candidates = [];
+    let pos = 0;
+    while (pos < value.length) {
+      // Skip whitespace and separator commas
+      while (pos < value.length && /[\s,]/.test(value.charAt(pos))) pos++;
+      if (pos >= value.length) break;
+      const start = pos;
+      // URL: a run of non-whitespace characters (which may contain commas)
+      while (pos < value.length && !/\s/.test(value.charAt(pos))) pos++;
+      if (value.charAt(pos - 1) === ',') {
+        // Trailing comma(s) end the candidate—a URL without descriptor
+        candidates.push(value.slice(start, pos).replace(/,+$/, ''));
+        continue;
+      }
+      // Descriptor: everything up to the next comma outside parentheses
+      let inParens = false;
+      while (pos < value.length && (inParens || value.charAt(pos) !== ',')) {
+        if (value.charAt(pos) === '(') inParens = true;
+        else if (value.charAt(pos) === ')') inParens = false;
+        pos++;
+      }
+      candidates.push(trimWhitespace(value.slice(start, pos)));
+    }
     const processed = candidates.map(candidate => {
       let url = candidate;
       let descriptor = '';

--- a/tests/html.spec.js
+++ b/tests/html.spec.js
@@ -3282,6 +3282,66 @@ describe('HTML', () => {
     assert.strictEqual(await minify(input, { minifyURLs: { site: 'https://example.com/' } }), output);
   });
 
+  // https://github.com/j9t/html-minifier-next/issues/304
+  test('`srcset` URLs containing commas', async () => {
+    let input, output;
+
+    // Commas within URLs must not be treated as candidate separators
+    input = '<img srcset="\n' +
+      '  /cdn-cgi/image/fit=contain,width=320/assets/hero.jpg   320w,\n' +
+      '  /cdn-cgi/image/fit=contain,width=640/assets/hero.jpg   640w"\n' +
+      '  src="/cdn-cgi/image/width=960/assets/hero.jpg">';
+    output = '<img srcset="/cdn-cgi/image/fit=contain,width=320/assets/hero.jpg 320w, /cdn-cgi/image/fit=contain,width=640/assets/hero.jpg 640w" src="/cdn-cgi/image/width=960/assets/hero.jpg">';
+    assert.strictEqual(await minify(input), output);
+
+    // Also on `source` elements, and for candidates without descriptors
+    input = '<source srcset="/img/a,b/x.jpg, /img/c,d/y.jpg 2x">';
+    output = '<source srcset="/img/a,b/x.jpg, /img/c,d/y.jpg 2x">';
+    assert.strictEqual(await minify(input), output);
+
+    // A separator comma without surrounding whitespace, after a descriptor
+    input = '<img srcset="a.jpg 320w,b.jpg 640w">';
+    output = '<img srcset="a.jpg 320w, b.jpg 640w">';
+    assert.strictEqual(await minify(input), output);
+
+    // Trailing comma(s) after a URL end the candidate
+    input = '<img srcset="a.jpg,, b.jpg 2x,">';
+    output = '<img srcset="a.jpg, b.jpg 2x">';
+    assert.strictEqual(await minify(input), output);
+
+    // Without whitespace after the comma, this is a single URL per the spec
+    input = '<img srcset="a.jpg,b.jpg 2x">';
+    output = '<img srcset="a.jpg,b.jpg 2x">';
+    assert.strictEqual(await minify(input), output);
+
+    // `minifyURLs` must receive the full URL, commas included
+    input = '<img srcset="https://example.com/image/fit=contain,width=320/a.jpg 320w, https://example.com/image/fit=contain,width=640/a.jpg 640w">';
+    output = '<img srcset="image/fit=contain,width=320/a.jpg 320w, image/fit=contain,width=640/a.jpg 640w">';
+    assert.strictEqual(await minify(input, { minifyURLs: { site: 'https://example.com/' } }), output);
+  });
+
+  test('`imagesrcset` attribute minification', async () => {
+    let input, output;
+
+    // `imagesrcset` on `link` is processed like `srcset`, including descriptor normalization
+    input = '<link rel="preload" as="image" imagesrcset="foo.jpg   1x,\n  bar.jpg 2.0x" imagesizes="100vw">';
+    output = '<link rel="preload" as="image" imagesrcset="foo.jpg, bar.jpg 2x" imagesizes="100vw">';
+    assert.strictEqual(await minify(input), output);
+
+    // Commas within URLs must not be treated as candidate separators
+    input = '<link rel="preload" as="image" imagesrcset="/cdn-cgi/image/fit=contain,width=320/hero.jpg 320w, /cdn-cgi/image/fit=contain,width=640/hero.jpg 640w">';
+    assert.strictEqual(await minify(input), input);
+
+    // `minifyURLs` applies to `imagesrcset` URLs
+    input = '<link rel="preload" as="image" imagesrcset="https://example.com/a.jpg 320w, https://example.com/b.jpg 640w">';
+    output = '<link rel="preload" as="image" imagesrcset="a.jpg 320w, b.jpg 640w">';
+    assert.strictEqual(await minify(input, { minifyURLs: { site: 'https://example.com/' } }), output);
+
+    // `imagesrcset` on other elements stays untouched
+    input = '<div imagesrcset="foo.jpg   1x"></div>';
+    assert.strictEqual(await minify(input), input);
+  });
+
   test('Async `minifyURLs` support', async () => {
     let input, output;
 


### PR DESCRIPTION
Resolves #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `imagesrcset` on image preload links, with the same URL minification and descriptor handling as `srcset`.

* **Bug Fixes**
  * Improved `srcset` parsing so URLs containing commas are handled correctly and no longer get split into separate candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->