### PR TITLE
Add cache statistics, limit cache entry size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Added cache hit/miss statistics for the CSS, JavaScript, and SVG minification caches: the `getCacheStats()` function exposes per-cache `gets`, `hits`, `size`, and `limit`; the CLI’s `--verbose` and `--dry` modes print a one-line-per-cache summary to STDERR at the end of a run, omitting caches that were never touched (e.g., when the corresponding minifier is disabled)
+* Added a fixed 1 MB entry size cap to the caches—oversized blocks are still minified normally but are no longer stored, bounding worst-case cache memory without affecting realistically sized inline content
 
 ## [7.2.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0] - 2026-07-17
+
+### Added
+
+* Added cache hit/miss statistics for the CSS, JavaScript, and SVG minification caches: the `getCacheStats()` function exposes per-cache `gets`, `hits`, `size`, and `limit`; the CLI’s `--verbose` and `--dry` modes print a one-line-per-cache summary to STDERR at the end of a run, omitting caches that were never touched (e.g., when the corresponding minifier is disabled)
+
 ## [7.2.0] - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -382,6 +382,26 @@ npx html-minifier-next --minify-css --minify-js --minify-svg input.html
 
 The caches persist across multiple `minify()` calls, making them particularly effective when processing many files in a batch operation.
 
+**Inspecting cache effectiveness:**
+
+Use `getCacheStats()` to see hit/miss counts and current occupancy for each cache:
+
+```js
+import { minify, getCacheStats } from 'html-minifier-next';
+
+await minify(html, { minifyCSS: true, minifyJS: true });
+console.log(getCacheStats());
+// {
+//   css: { gets: 3, hits: 1, size: 2, limit: 500 },
+//   js: { gets: 1, hits: 0, size: 1, limit: 500 },
+//   svg: { gets: 0, hits: 0, size: 0, limit: 500 }
+// }
+```
+
+A cache that was never exercised (e.g., `minifySVG` disabled, or `minify()` not yet called) reports all-zero stats.
+
+The CLI’s `--verbose` and `--dry` modes print the same information to STDERR at the end of a run, omitting caches that were never touched.
+
 ## Minification comparison
 
 Please see [**the Minifier Benchmarks project**](https://github.com/j9t/minifier-benchmarks) for details on how HTML Minifier Next compares to other minifiers.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ npx html-minifier-next --minify-css --minify-js --minify-svg input.html
 
 * Cache locking: Caches are created on the first `minify()` call and persist for the process lifetime. Cache sizes are locked after first initialization—subsequent calls reuse the same caches even if different `cacheCSS`, `cacheJS`, or `cacheSVG` options are provided. The first call’s options determine the cache sizes.
 * Zero values: Explicit `0` values are coerced to `1` (minimum functional cache size) to avoid immediate eviction. To keep the cache footprint as small as possible, use a small number like `10` or `50` instead of `0`.
+* Entry size cap: Individual CSS, JavaScript, or SVG blocks larger than 1 MB are minified normally but not stored in the cache—this bounds worst-case cache memory without affecting realistically sized inline content. (This cutoff is fixed and not configurable.)
 
 The caches persist across multiple `minify()` calls, making them particularly effective when processing many files in a batch operation.
 

--- a/README.md
+++ b/README.md
@@ -663,6 +663,6 @@ With many thanks to the previous authors of and contributors to HTML Minifier, e
 
 You might like some of my other work:
 
-* Optimization tools: [hihtml](https://github.com/j9t/hihtml) · HTML Minifier Next · [ObsoHTML](https://github.com/j9t/obsohtml) · [Image Guard](https://github.com/j9t/image-guard) · [Compressor.js Next](https://github.com/j9t/compressorjs-next) · [.htaccess Punk](https://github.com/j9t/htaccess-punk)
+* Optimization tools: [hihtml](https://github.com/j9t/hihtml) · HTML Minifier Next · [ObsoHTML](https://github.com/j9t/obsohtml) · [CSS Dedup](https://github.com/j9t/css-dedup) · [Image Guard](https://github.com/j9t/image-guard) · [Compressor.js Next](https://github.com/j9t/compressorjs-next) · [.htaccess Punk](https://github.com/j9t/htaccess-punk)
 * Defense tools: [IA Defensa](https://iadefensa.com/solutions/)
 * Resources for quality web development: [Articles](https://meiert.com/topics/development/) · [Books](https://meiert.com/topics/books/) (including [_On Web Development_](https://meiert.com/blog/on-web-development-2/)) · [News](https://frontenddogma.com/) · [Terminology](https://webglossary.info/)

--- a/README.md
+++ b/README.md
@@ -390,11 +390,15 @@ Use `getCacheStats()` to see hit/miss counts and current occupancy for each cach
 ```js
 import { minify, getCacheStats } from 'html-minifier-next';
 
-await minify(html, { minifyCSS: true, minifyJS: true });
+// After minifying pages that share templated CSS/JS…
+for (const html of pages) {
+  await minify(html, { minifyCSS: true, minifyJS: true });
+}
+
 console.log(getCacheStats());
 // {
-//   css: { gets: 3, hits: 1, size: 2, limit: 500 },
-//   js: { gets: 1, hits: 0, size: 1, limit: 500 },
+//   css: { gets: 392, hits: 298, size: 94, limit: 500 },
+//   js: { gets: 1196, hits: 1192, size: 4, limit: 500 },
 //   svg: { gets: 0, hits: 0, size: 0, limit: 500 }
 // }
 ```

--- a/cli.js
+++ b/cli.js
@@ -452,6 +452,26 @@ program.helpOption('-h, --help', 'Display help for command');
     return { originalSize, minifiedSize, saved, sign, percentage };
   }
 
+  // Print a one-line-per-cache hits/misses/size summary to STDERR, skipping caches
+  // that were never touched (e.g., their minifier is disabled)
+  async function printCacheStats() {
+    const { getCacheStats } = await import('./src/htmlminifier.js');
+    const cacheStats = getCacheStats();
+    const labels = { css: 'CSS', js: 'JS', svg: 'SVG' };
+
+    const lines = Object.keys(labels).reduce((acc, key) => {
+      const { gets, hits, size, limit } = cacheStats[key];
+      if (gets === 0) return acc;
+      const misses = gets - hits;
+      acc.push(`  ${labels[key]} cache: ${hits.toLocaleString()} hit${hits === 1 ? '' : 's'}, ${misses.toLocaleString()} miss${misses === 1 ? '' : 'es'}, ${size.toLocaleString()}/${limit.toLocaleString()} entries`);
+      return acc;
+    }, []);
+
+    if (lines.length === 0) return;
+    console.error('Cache stats:');
+    lines.forEach(line => console.error(line));
+  }
+
   async function processFile(inputFile, outputFile, isDryRun = false, isVerbose = false) {
     const data = await fs.promises.readFile(inputFile, { encoding: 'utf8' }).catch(err => {
       fatal('Cannot read ' + inputFile + '\n' + err.message);
@@ -698,6 +718,7 @@ program.helpOption('-h, --help', 'Display help for command');
       console.error(`  Original: ${stats.originalSize.toLocaleString()} bytes`);
       console.error(`  Minified: ${stats.minifiedSize.toLocaleString()} bytes`);
       console.error(`  Saved: ${stats.sign}${Math.abs(stats.saved).toLocaleString()} bytes (${stats.percentage}%)`);
+      await printCacheStats();
       return;
     }
 
@@ -705,6 +726,7 @@ program.helpOption('-h, --help', 'Display help for command');
     if (programOptions.verbose) {
       const inputSource = program.args.length > 0 ? program.args.join(', ') : 'STDIN';
       console.error(`  ${MARK_SUCCESS}✓${MARK_RESET} ${inputSource}: ${stats.originalSize.toLocaleString()} → ${stats.minifiedSize.toLocaleString()} bytes (${stats.sign}${Math.abs(stats.saved).toLocaleString()}, ${stats.percentage}%)`);
+      await printCacheStats();
     }
 
     if (programOptions.output) {
@@ -833,6 +855,10 @@ program.helpOption('-h, --help', 'Display help for command');
         console.error('---');
         console.error(`Total: ${totalOriginal.toLocaleString()} → ${totalMinified.toLocaleString()} bytes (${sign}${Math.abs(totalSaved).toLocaleString()}, ${totalPercentage}%)`);
       }
+
+      if (isVerbose) {
+        await printCacheStats();
+      }
     })();
   } else if (filesProvided) { // Minifying one or more files specified on the CMD line
     // Process each file independently, then concatenate outputs
@@ -881,12 +907,14 @@ program.helpOption('-h, --help', 'Display help for command');
       console.error(`  Original: ${stats.originalSize.toLocaleString()} bytes`);
       console.error(`  Minified: ${stats.minifiedSize.toLocaleString()} bytes`);
       console.error(`  Saved: ${stats.sign}${Math.abs(stats.saved).toLocaleString()} bytes (${stats.percentage}%)`);
+      await printCacheStats();
       process.exit(0);
     }
 
     if (programOptions.verbose) {
       const inputSource = capturedFiles.join(', ');
       console.error(`  ${MARK_SUCCESS}✓${MARK_RESET} ${inputSource}: ${stats.originalSize.toLocaleString()} → ${stats.minifiedSize.toLocaleString()} bytes (${stats.sign}${Math.abs(stats.saved).toLocaleString()}, ${stats.percentage}%)`);
+      await printCacheStats();
     }
 
     if (programOptions.output) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -93,5 +93,5 @@
     "test:watch": "node --test --watch tests/*.spec.js"
   },
   "type": "module",
-  "version": "7.2.0"
+  "version": "7.3.0"
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -529,6 +529,22 @@ let jsMinifyCache = null;
 /** @type {LRU | null} */
 let svgMinifyCache = null;
 
+/**
+ * @typedef {Object} CacheStats
+ *  Hit/miss statistics and current occupancy for a single minification cache.
+ *
+ * @prop {number} gets Number of lookups attempted against the cache.
+ * @prop {number} hits Number of lookups that found a cached entry.
+ * @prop {number} size Number of entries currently held in the cache.
+ * @prop {number} limit Maximum number of entries the cache can hold.
+ */
+
+/**
+ * @param {LRU | null} cache
+ * @returns {CacheStats}
+ */
+const cacheStatsOrEmpty = (cache) => cache ? cache.stats() : { gets: 0, hits: 0, size: 0, limit: 0 };
+
 // Pre-compiled patterns for script merging (avoid repeated allocation in hot path)
 const RE_SCRIPT_ATTRS = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
 const RE_SCRIPT_OPEN = /<script(?=[\s>])/gi; // Finds tag start; use `findTagEnd()` for the actual closing `>`
@@ -1894,6 +1910,23 @@ function initCaches(options) {
 }
 
 /**
+ * Get hit/miss statistics for the CSS, JavaScript, and SVG minification caches.
+ *
+ * Each cache is created lazily on the first `minify()` call (see `initCaches`); before
+ * that first call, or for a cache never exercised (e.g., `minifyCSS` disabled), its
+ * entry reports all-zero stats.
+ *
+ * @returns {{ css: CacheStats, js: CacheStats, svg: CacheStats }}
+ */
+export function getCacheStats() {
+  return {
+    css: cacheStatsOrEmpty(cssMinifyCache),
+    js: cacheStatsOrEmpty(jsMinifyCache),
+    svg: cacheStatsOrEmpty(svgMinifyCache)
+  };
+}
+
+/**
  * @param {string} value
  * @param {MinifierOptions} [options]
  * @returns {Promise<string>}
@@ -1926,4 +1959,4 @@ export const minify = async function (value, options) {
 
 export { presets, getPreset, getPresetNames };
 
-export default { minify, presets, getPreset, getPresetNames };
+export default { minify, presets, getPreset, getPresetNames, getCacheStats };

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -183,13 +183,15 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys
         const inputCSS = wrapCSS(text, type);
         const cssSig = stableStringify({ type, opts: lightningCssOptions, cont: !!options.continueOnMinifyError });
-        const cssKey = inputCSS.length > 2048
-          ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
-          : (inputCSS + '|' + type + '|' + cssSig);
         const isCacheable = inputCSS.length <= MAX_CACHEABLE_INPUT_LENGTH;
+        const cssKey = isCacheable
+          ? (inputCSS.length > 2048
+            ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
+            : (inputCSS + '|' + type + '|' + cssSig))
+          : undefined;
 
         try {
-          if (isCacheable) {
+          if (cssKey !== undefined) {
             const cached = /** @type {string | Promise<string> | undefined} */ (cssCache.get(cssKey));
             if (cached !== undefined) {
               // Support both resolved values and in-flight promises
@@ -227,12 +229,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             return (text.trim() && !outputCSS.trim() && (looksLikeTemplate || hasUID)) ? text : outputCSS;
           })();
 
-          if (isCacheable) cssCache.set(cssKey, inFlight);
+          if (cssKey !== undefined) cssCache.set(cssKey, inFlight);
           const resolved = await inFlight;
-          if (isCacheable) cssCache.set(cssKey, resolved);
+          if (cssKey !== undefined) cssCache.set(cssKey, resolved);
           return resolved;
         } catch (err) {
-          if (isCacheable) cssCache.delete(cssKey);
+          if (cssKey !== undefined) cssCache.delete(cssKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -303,11 +305,11 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           // Select pre-computed signature based on engine
           const optsSig = useEngine === 'terser' ? terserSig : swcSig;
 
-          // For large inputs, hash the full content to avoid storing huge strings as Map keys
-          jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
-            + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
-
           if (isCacheable) {
+            // For large inputs, hash the full content to avoid storing huge strings as Map keys
+            jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
+              + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
+
             const cached = /** @type {string | Promise<string> | undefined} */ (jsCache.get(jsKey));
             if (cached !== undefined) {
               return await cached;
@@ -343,12 +345,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             throw new Error(`Unknown JS minifier engine: ${useEngine}`);
           })();
 
-          if (isCacheable) jsCache.set(jsKey, inFlight);
+          if (jsKey !== undefined) jsCache.set(jsKey, inFlight);
           const resolved = await inFlight;
-          if (isCacheable) jsCache.set(jsKey, resolved);
+          if (jsKey !== undefined) jsCache.set(jsKey, resolved);
           return resolved;
         } catch (err) {
-          if (isCacheable && jsKey) jsCache.delete(jsKey);
+          if (jsKey !== undefined) jsCache.delete(jsKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -422,14 +424,15 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           return svgContent;
         }
 
-        // Cache key: Large inputs are hashed to avoid huge Map keys
-        const svgKey = svgContent.length > 2048
-          ? (hashContent(svgContent) + '|' + svgSig)
-          : (svgContent + '|' + svgSig);
         const isCacheable = svgContent.length <= MAX_CACHEABLE_INPUT_LENGTH;
+        const svgKey = isCacheable
+          ? (svgContent.length > 2048
+            ? (hashContent(svgContent) + '|' + svgSig)
+            : (svgContent + '|' + svgSig))
+          : undefined;
 
         try {
-          if (isCacheable) {
+          if (svgKey !== undefined) {
             const cached = /** @type {string | Promise<string> | undefined} */ (svgCache.get(svgKey));
             if (cached !== undefined) {
               return await cached;
@@ -442,12 +445,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             return result.data;
           })();
 
-          if (isCacheable) svgCache.set(svgKey, inFlight);
+          if (svgKey !== undefined) svgCache.set(svgKey, inFlight);
           const resolved = await inFlight;
-          if (isCacheable) svgCache.set(svgKey, resolved);
+          if (svgKey !== undefined) svgCache.set(svgKey, resolved);
           return resolved;
         } catch (err) {
-          if (isCacheable) svgCache.delete(svgKey);
+          if (svgKey !== undefined) svgCache.delete(svgKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,5 +1,5 @@
 import { createUrlMinifier } from './urls.js';
-import { LRU, MAX_CACHEABLE_INPUT_LENGTH, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
+import { LRU, MAX_CACHE_ENTRY_SIZE, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
 import { RE_TRAILING_SEMICOLON } from './constants.js';
 import { canCollapseWhitespace, canTrimWhitespace } from './whitespace.js';
 import { wrapCSS, unwrapCSS } from './content.js';
@@ -183,7 +183,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys
         const inputCSS = wrapCSS(text, type);
         const cssSig = stableStringify({ type, opts: lightningCssOptions, cont: !!options.continueOnMinifyError });
-        const isCacheable = inputCSS.length <= MAX_CACHEABLE_INPUT_LENGTH;
+        const isCacheable = inputCSS.length <= MAX_CACHE_ENTRY_SIZE;
         const cssKey = isCacheable
           ? (inputCSS.length > 2048
             ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
@@ -299,7 +299,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         // Use user’s chosen engine for script blocks
         const useEngine = inline ? 'terser' : engine;
         let jsKey;
-        const isCacheable = code.length <= MAX_CACHEABLE_INPUT_LENGTH;
+        const isCacheable = code.length <= MAX_CACHE_ENTRY_SIZE;
 
         try {
           // Select pre-computed signature based on engine
@@ -424,7 +424,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           return svgContent;
         }
 
-        const isCacheable = svgContent.length <= MAX_CACHEABLE_INPUT_LENGTH;
+        const isCacheable = svgContent.length <= MAX_CACHE_ENTRY_SIZE;
         const svgKey = isCacheable
           ? (svgContent.length > 2048
             ? (hashContent(svgContent) + '|' + svgSig)

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,5 +1,5 @@
 import { createUrlMinifier } from './urls.js';
-import { LRU, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
+import { LRU, MAX_CACHEABLE_INPUT_LENGTH, stableStringify, hashContent, identity, lowercase, replaceAsync, parseRegExp } from './utils.js';
 import { RE_TRAILING_SEMICOLON } from './constants.js';
 import { canCollapseWhitespace, canTrimWhitespace } from './whitespace.js';
 import { wrapCSS, unwrapCSS } from './content.js';
@@ -186,12 +186,15 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         const cssKey = inputCSS.length > 2048
           ? (hashContent(inputCSS) + '|' + type + '|' + cssSig)
           : (inputCSS + '|' + type + '|' + cssSig);
+        const isCacheable = inputCSS.length <= MAX_CACHEABLE_INPUT_LENGTH;
 
         try {
-          const cached = /** @type {string | Promise<string> | undefined} */ (cssCache.get(cssKey));
-          if (cached !== undefined) {
-            // Support both resolved values and in-flight promises
-            return await cached;
+          if (isCacheable) {
+            const cached = /** @type {string | Promise<string> | undefined} */ (cssCache.get(cssKey));
+            if (cached !== undefined) {
+              // Support both resolved values and in-flight promises
+              return await cached;
+            }
           }
 
           // In-flight promise caching: Prevent duplicate concurrent minifications
@@ -224,12 +227,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             return (text.trim() && !outputCSS.trim() && (looksLikeTemplate || hasUID)) ? text : outputCSS;
           })();
 
-          cssCache.set(cssKey, inFlight);
+          if (isCacheable) cssCache.set(cssKey, inFlight);
           const resolved = await inFlight;
-          cssCache.set(cssKey, resolved);
+          if (isCacheable) cssCache.set(cssKey, resolved);
           return resolved;
         } catch (err) {
-          cssCache.delete(cssKey);
+          if (isCacheable) cssCache.delete(cssKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -293,8 +296,9 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         // Hybrid strategy: Always use Terser for inline JS (needs bare returns support)
         // Use user’s chosen engine for script blocks
         const useEngine = inline ? 'terser' : engine;
-
         let jsKey;
+        const isCacheable = code.length <= MAX_CACHEABLE_INPUT_LENGTH;
+
         try {
           // Select pre-computed signature based on engine
           const optsSig = useEngine === 'terser' ? terserSig : swcSig;
@@ -303,9 +307,11 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           jsKey = (code.length > 2048 ? (hashContent(code) + '|') : (code + '|'))
             + (inline ? '1' : '0') + '|' + (isModule ? 'm' : '') + '|' + useEngine + '|' + optsSig;
 
-          const cached = /** @type {string | Promise<string> | undefined} */ (jsCache.get(jsKey));
-          if (cached !== undefined) {
-            return await cached;
+          if (isCacheable) {
+            const cached = /** @type {string | Promise<string> | undefined} */ (jsCache.get(jsKey));
+            if (cached !== undefined) {
+              return await cached;
+            }
           }
 
           const inFlight = (async () => {
@@ -337,12 +343,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             throw new Error(`Unknown JS minifier engine: ${useEngine}`);
           })();
 
-          jsCache.set(jsKey, inFlight);
+          if (isCacheable) jsCache.set(jsKey, inFlight);
           const resolved = await inFlight;
-          jsCache.set(jsKey, resolved);
+          if (isCacheable) jsCache.set(jsKey, resolved);
           return resolved;
         } catch (err) {
-          if (jsKey) jsCache.delete(jsKey);
+          if (isCacheable && jsKey) jsCache.delete(jsKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }
@@ -420,11 +426,14 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         const svgKey = svgContent.length > 2048
           ? (hashContent(svgContent) + '|' + svgSig)
           : (svgContent + '|' + svgSig);
+        const isCacheable = svgContent.length <= MAX_CACHEABLE_INPUT_LENGTH;
 
         try {
-          const cached = /** @type {string | Promise<string> | undefined} */ (svgCache.get(svgKey));
-          if (cached !== undefined) {
-            return await cached;
+          if (isCacheable) {
+            const cached = /** @type {string | Promise<string> | undefined} */ (svgCache.get(svgKey));
+            if (cached !== undefined) {
+              return await cached;
+            }
           }
 
           const inFlight = (async () => {
@@ -433,12 +442,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
             return result.data;
           })();
 
-          svgCache.set(svgKey, inFlight);
+          if (isCacheable) svgCache.set(svgKey, inFlight);
           const resolved = await inFlight;
-          svgCache.set(svgKey, resolved);
+          if (isCacheable) svgCache.set(svgKey, resolved);
           return resolved;
         } catch (err) {
-          svgCache.delete(svgKey);
+          if (isCacheable) svgCache.delete(svgKey);
           if (!options.continueOnMinifyError) {
             throw err;
           }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -21,12 +21,16 @@ function stableStringify(obj) {
 class LRU {
   constructor(limit = 200) {
     this.limit = limit;
+    this.gets = 0;
+    this.hits = 0;
     /** @type {Map<string, unknown>} */
     this.map = new Map();
   }
   /** @param {string} key */
   get(key) {
+    this.gets++;
     if (this.map.has(key)) {
+      this.hits++;
       const v = this.map.get(key);
       this.map.delete(key);
       this.map.set(key, v);
@@ -48,6 +52,10 @@ class LRU {
   }
   /** @param {string} key */
   delete(key) { this.map.delete(key); }
+  /** @returns {{ gets: number, hits: number, size: number, limit: number }} */
+  stats() {
+    return { gets: this.gets, hits: this.hits, size: this.map.size, limit: this.limit };
+  }
 }
 
 // FNV-1a 32-bit hash for large-input cache keys

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -58,6 +58,11 @@ class LRU {
   }
 }
 
+// Content longer than this (in UTF-16 code units, roughly bytes for typical CSS/JS/SVG) is
+// minified normally but never stored in a minification cache—caps worst-case cache memory
+// (entry count × this size) without affecting realistically sized inline content
+const MAX_CACHEABLE_INPUT_LENGTH = 1024 * 1024; // 1 MB
+
 // FNV-1a 32-bit hash for large-input cache keys
 
 /** @param {string} str */
@@ -143,6 +148,7 @@ function parseRegExp(value) {
 
 export { stableStringify };
 export { LRU };
+export { MAX_CACHEABLE_INPUT_LENGTH };
 export { hashContent };
 export { uniqueId };
 export { identity };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -61,7 +61,7 @@ class LRU {
 // Content longer than this (in UTF-16 code units, roughly bytes for typical CSS/JS/SVG) is
 // minified normally but never stored in a minification cache—caps worst-case cache memory
 // (entry count × this size) without affecting realistically sized inline content
-const MAX_CACHEABLE_INPUT_LENGTH = 1024 * 1024; // 1 MB
+const MAX_CACHE_ENTRY_SIZE = 1024 * 1024; // 1 MB
 
 // FNV-1a 32-bit hash for large-input cache keys
 
@@ -148,7 +148,7 @@ function parseRegExp(value) {
 
 export { stableStringify };
 export { LRU };
-export { MAX_CACHEABLE_INPUT_LENGTH };
+export { MAX_CACHE_ENTRY_SIZE };
 export { hashContent };
 export { uniqueId };
 export { identity };

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -1259,6 +1259,49 @@ describe('CLI', () => {
     await fs.promises.rm(configPath, { force: true });
   });
 
+  test('Verbose mode prints cache stats, omitting caches that were never touched', () => {
+    // Duplicate `<style>` block to trigger a CSS cache hit; single `<script>` to keep JS at a miss;
+    // no `<svg>`/`minifySVG`, so the SVG cache must be omitted entirely
+    const input = '<style>body{color:red}</style><style>body{color:red}</style><script>let a=1;</script>';
+    const { stdout, stderr, status } = spawnSync('node', [cliPath, '--minify-css', '--minify-js', '--verbose'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    assert.strictEqual(status, 0);
+    const stderrText = stderr.toString();
+    assert.ok(stderrText.includes('Cache stats:'));
+    assert.ok(stderrText.includes('CSS cache: 1 hit, 1 miss, 1/500 entries'));
+    assert.ok(stderrText.includes('JS cache: 0 hits, 1 miss, 1/500 entries'));
+    assert.ok(!stderrText.includes('SVG cache:'), 'SVG cache was never touched and should be omitted');
+    assert.ok(stdout.toString().length > 0);
+  });
+
+  test('Dry run prints cache stats', () => {
+    const input = '<style>body{color:blue}</style>';
+    const { stderr, status } = spawnSync('node', [cliPath, '--minify-css', '--dry'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    assert.strictEqual(status, 0);
+    const stderrText = stderr.toString();
+    assert.ok(stderrText.includes('[DRY RUN]'));
+    assert.ok(stderrText.includes('Cache stats:'));
+    assert.ok(stderrText.includes('CSS cache: 0 hits, 1 miss, 1/500 entries'));
+  });
+
+  test('Cache stats are omitted entirely when no cache was touched', () => {
+    const input = '<p>Hello</p>';
+    const { stderr, status } = spawnSync('node', [cliPath, '--verbose'], {
+      cwd: fixturesDir,
+      input
+    });
+
+    assert.strictEqual(status, 0);
+    assert.ok(!stderr.toString().includes('Cache stats:'));
+  });
+
   test('Should throw error for invalid cache-css value', () => {
     const cliArguments = [
       'default.html',

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -1,6 +1,6 @@
 import {describe, test} from 'node:test';
 import assert from 'node:assert';
-import { minify } from '../src/htmlminifier.js';
+import { minify, getCacheStats } from '../src/htmlminifier.js';
 
 describe('CSS and JS', () => {
   test('CSS minification', async () => {
@@ -986,6 +986,35 @@ describe('CSS and JS', () => {
       assert.notStrictEqual(result1, result2, 'Different large JS inputs must not share a cache entry');
       assert.ok(result1.includes('1111'), 'First result should contain the correct value');
       assert.ok(result2.includes('2222'), 'Second result should contain the correct value');
+    });
+
+    test('`getCacheStats()` reflects hits and misses', async () => {
+      // Unique selector so this test’s lookups are unaffected by entries other tests left behind
+      const input = '<style>.cache-stats-probe { color: rebeccapurple; }</style>';
+
+      const before = getCacheStats().css;
+      await minify(input, { minifyCSS: true }); // First call: a miss (populates the cache)
+      await minify(input, { minifyCSS: true }); // Second call: a hit (same key, already cached)
+      const after = getCacheStats().css;
+
+      assert.strictEqual(after.gets - before.gets, 2, 'Both calls should perform a cache lookup');
+      assert.strictEqual(after.hits - before.hits, 1, 'Only the second, identical call should hit the cache');
+      assert.ok(after.size >= 1, 'Cache should hold at least the entry just inserted');
+      assert.strictEqual(after.limit, 500, 'Default cache limit should be reported');
+    });
+
+    test('`getCacheStats()` omits caches with no effect on untouched caches', async () => {
+      // Only CSS caching is exercised—JS and SVG lookups must not be incremented by this call
+      const jsBefore = getCacheStats().js;
+      const svgBefore = getCacheStats().svg;
+
+      await minify('<style>.cache-stats-probe-2 { color: teal; }</style>', { minifyCSS: true });
+
+      const jsAfter = getCacheStats().js;
+      const svgAfter = getCacheStats().svg;
+
+      assert.strictEqual(jsAfter.gets, jsBefore.gets, 'JS cache should not be touched when `minifyJS` is off');
+      assert.strictEqual(svgAfter.gets, svgBefore.gets, 'SVG cache should not be touched when `minifySVG` is off');
     });
   });
 });

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -1016,5 +1016,35 @@ describe('CSS and JS', () => {
       assert.strictEqual(jsAfter.gets, jsBefore.gets, 'JS cache should not be touched when `minifyJS` is off');
       assert.strictEqual(svgAfter.gets, svgBefore.gets, 'SVG cache should not be touched when `minifySVG` is off');
     });
+
+    test('Oversized CSS input (>1 MB) is minified normally but never cached', async () => {
+      const bigComment = '/*' + 'x'.repeat(1024 * 1024) + '*/';
+      const input = `<style>.oversize-probe{color:tomato}${bigComment}</style>`;
+
+      const before = getCacheStats().css;
+      const result1 = await minify(input, { minifyCSS: true });
+      const result2 = await minify(input, { minifyCSS: true });
+      const after = getCacheStats().css;
+
+      assert.strictEqual(result1, result2, 'Result should be identical whether or not it was cached');
+      assert.ok(result1.includes('.oversize-probe{color:tomato}'), 'CSS should still be minified');
+      assert.strictEqual(after.gets, before.gets, 'Oversized input should never reach `cache.get()`');
+      assert.strictEqual(after.size, before.size, 'Oversized input should never be stored in the cache');
+    });
+
+    test('Oversized JS input (>1 MB) is minified normally but never cached', async () => {
+      const bigComment = '/*' + 'x'.repeat(1024 * 1024) + '*/';
+      const input = `<script>function oversizeProbe(){return 42}${bigComment}</script>`;
+
+      const before = getCacheStats().js;
+      const result1 = await minify(input, { minifyJS: true });
+      const result2 = await minify(input, { minifyJS: true });
+      const after = getCacheStats().js;
+
+      assert.strictEqual(result1, result2, 'Result should be identical whether or not it was cached');
+      assert.ok(result1.includes('return 42'), 'JS should still be minified');
+      assert.strictEqual(after.gets, before.gets, 'Oversized input should never reach `cache.get()`');
+      assert.strictEqual(after.size, before.size, 'Oversized input should never be stored in the cache');
+    });
   });
 });

--- a/tests/svg+mathml.spec.js
+++ b/tests/svg+mathml.spec.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import {describe, test} from 'node:test';
-import { minify } from '../src/htmlminifier.js';
+import { minify, getCacheStats } from '../src/htmlminifier.js';
 
 describe('SVG and MathML', () => {
   test('SVGO basic optimization', async () => {
@@ -599,5 +599,20 @@ describe('SVG and MathML', () => {
     const withSVGOff = await minify(input, { preset: 'comprehensive', minifySVG: false });
     assert.ok(withSVGMin.includes('<path'), 'SVGO should convert `rect` to `path` when `minifySVG` is enabled');
     assert.ok(!withSVGOff.includes('<path'), '`rect` should be preserved when `minifySVG` is overridden to false');
+  });
+
+  test('Oversized SVG input (>1 MB) is minified normally but never cached', async () => {
+    const bigComment = '<!-- ' + 'x'.repeat(1024 * 1024) + ' -->';
+    const input = `<svg><circle cx="10" cy="10" r="5"/>${bigComment}</svg>`;
+
+    const before = getCacheStats().svg;
+    const result1 = await minify(input, { minifySVG: true });
+    const result2 = await minify(input, { minifySVG: true });
+    const after = getCacheStats().svg;
+
+    assert.strictEqual(result1, result2, 'Result should be identical whether or not it was cached');
+    assert.ok(result1.includes('<circle'), 'SVG should still be minified');
+    assert.strictEqual(after.gets, before.gets, 'Oversized input should never reach `cache.get()`');
+    assert.strictEqual(after.size, before.size, 'Oversized input should never be stored in the cache');
   });
 });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,0 +1,59 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { LRU } from '../src/lib/utils.js';
+
+describe('LRU', () => {
+  test('New cache reports all-zero stats', () => {
+    const cache = new LRU(3);
+    assert.deepStrictEqual(cache.stats(), { gets: 0, hits: 0, size: 0, limit: 3 });
+  });
+
+  test('`get()` on a missing key counts a get but not a hit', () => {
+    const cache = new LRU(3);
+    assert.strictEqual(cache.get('missing'), undefined);
+    assert.deepStrictEqual(cache.stats(), { gets: 1, hits: 0, size: 0, limit: 3 });
+  });
+
+  test('`get()` on a present key counts both a get and a hit', () => {
+    const cache = new LRU(3);
+    cache.set('key', 'value');
+    assert.strictEqual(cache.get('key'), 'value');
+    assert.deepStrictEqual(cache.stats(), { gets: 1, hits: 1, size: 1, limit: 3 });
+  });
+
+  test('Repeated lookups accumulate gets and hits independently', () => {
+    const cache = new LRU(3);
+    cache.set('a', 1);
+
+    cache.get('a'); // hit
+    cache.get('b'); // miss
+    cache.get('a'); // hit
+    cache.get('c'); // miss
+
+    const stats = cache.stats();
+    assert.strictEqual(stats.gets, 4);
+    assert.strictEqual(stats.hits, 2);
+  });
+
+  test('`set()` does not affect gets/hits counters', () => {
+    const cache = new LRU(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    assert.deepStrictEqual(cache.stats(), { gets: 0, hits: 0, size: 2, limit: 3 });
+  });
+
+  test('`stats()` size reflects eviction once the limit is exceeded', () => {
+    const cache = new LRU(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3); // evicts `a`—limit is 2
+
+    assert.strictEqual(cache.stats().size, 2);
+    assert.strictEqual(cache.get('a'), undefined); // miss—evicted
+    assert.strictEqual(cache.get('c'), 3); // hit—still present
+
+    const stats = cache.stats();
+    assert.strictEqual(stats.gets, 2);
+    assert.strictEqual(stats.hits, 1);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `getCacheStats()` to expose per-cache hit/miss counts and current size/limit.
  - CLI `--verbose`/`--dry` now prints per-cache cache stats to STDERR only for caches that were actually exercised.
  - Enforced a fixed 1 MB maximum cache entry size: oversized inputs are minified but never stored.
- **Documentation**
  - Updated changelog and README with cache stats examples and the entry size cap behavior.
- **Tests**
  - Expanded coverage for cache stat reporting, CLI STDERR output, and oversized-input cache bypass behavior (including eviction/`LRU.stats()` checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->