### PR TITLE
Add `types` field for better type definition recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.1] - 2026-07-26
+
+### Added
+
+* Added a top-level `types` field mirroring the `exports` types condition, so that the bundled type definitions are recognized by npmjs.com and by projects still on TypeScript’s legacy `node` module resolution
+
 ## [7.5.0] - 2026-07-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -93,5 +93,6 @@
     "test:watch": "node --test --watch tests/*.spec.js"
   },
   "type": "module",
-  "version": "7.5.0"
+  "types": "dist/types/htmlminifier.d.ts",
+  "version": "7.5.1"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved package type-definition discovery for npmjs.com and older TypeScript module resolution.

* **Chores**
  * Bumped the package version to 7.5.1.
  * Documented the release in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->