### PR TITLE
Escape `<` in JSON script content during minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.2] - 2026-07-27
+
+### Fixed
+
+* Fixed JSON script minification decoding `<` escapes
+
 ## [7.5.1] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fixed JSON script minification decoding `<` escapes
+* Fixed JSON script minification decoding `<` escapes, which let a `</script>` inside a payload end the script element—`<` is now escaped as `\u003C` in the output
 
 ## [7.5.1] - 2026-07-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-next",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-next",
-      "version": "7.5.1",
+      "version": "7.5.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
   },
   "type": "module",
   "types": "dist/types/htmlminifier.d.ts",
-  "version": "7.5.1"
+  "version": "7.5.2"
 }

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -43,13 +43,14 @@ function unwrapCSS(text, type) {
 
 // Script processing
 
+// Minify JSON script content, keeping `<` escaped
 /**
  * @param {string} text
  * @param {{continueOnMinifyError?: boolean, log?: Function}} options
  */
 function minifyJson(text, options) {
   try {
-    return JSON.stringify(JSON.parse(text));
+    return JSON.stringify(JSON.parse(text)).replace(/</g, '\\u003C');
   }
   catch (err) {
     if (!options.continueOnMinifyError) {

--- a/tests/css+js.spec.js
+++ b/tests/css+js.spec.js
@@ -747,6 +747,26 @@ describe('CSS and JS', () => {
     }
   });
 
+  test('JSON script content keeps `<` escaped', async () => {
+    // A framework hydration payload: HTML held inside JSON, with `<` and `/`
+    // escaped so the nested `</script>` cannot terminate the container
+    const input = '<script type="application/json">{\n  "content": "\\u003Cscript\\u003Ealert(1)\\u003C\\u002Fscript\\u003E"\n}</script>';
+    const result = await minify(input, { collapseWhitespace: true });
+
+    assert.ok(!/<\/script/i.test(result.slice(result.indexOf('>') + 1, result.lastIndexOf('</script>'))), 'JSON content must not contain a literal `</script`');
+    assert.strictEqual(result, '<script type="application/json">{"content":"\\u003Cscript>alert(1)\\u003C/script>"}</script>');
+
+    // The escaping must not change what the JSON parses to
+    const value = JSON.parse(result.slice(result.indexOf('>') + 1, result.lastIndexOf('</script>')));
+    assert.strictEqual(value.content, '<script>alert(1)</script>');
+  });
+
+  test('JSON script content without markup is unaffected', async () => {
+    const input = '<script type="application/ld+json">{\n  "@type": "Person",\n  "name": "Test"\n}</script>';
+    const output = '<script type="application/ld+json">{"@type":"Person","name":"Test"}</script>';
+    assert.strictEqual(await minify(input, { collapseWhitespace: true }), output);
+  });
+
   test('JSON minification error handling', async () => {
     // Malformed JSON should be preserved with default `continueOnMinifyError: true`
     let input = '<script type="application/ld+json">{"foo:  "bar"}</script>';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed minification of JSON embedded in `<script>` tags so HTML-like sequences (including `</script>`) can’t prematurely terminate the script element.
  * Ensured minified JSON remains safe by encoding `<` characters and still parses back to the original value.

* **Tests**
  * Added coverage for JSON-in-`<script>` handling (including whitespace-collapsed minification) and `application/ld+json` payloads.

* **Release**
  * Updated the package version to **7.5.2** and refreshed the changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->