### PR TITLE
Add `removeUnusedCSS` option, improve diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Added `removeUnusedCSS` option to enable removing rules from `style` elements whose class or ID selectors the document never references (requires `minifyCSS`, since removal runs through Lightning CSS)
 * Added minifier diagnostics to `--verbose` (and `--dry`, which implies it)
-* Added reporting for invalid CSS under `errorRecovery`: With `continueOnMinifyError` enabled (the default), Lightning CSS reports invalid rules instead of throwing; it is reported through the `log` hook, once per document and for every document
+* Added reporting for invalid CSS under `errorRecovery`—with `continueOnMinifyError` enabled (the default), Lightning CSS reports invalid rules instead of throwing, which is done through the `log` hook
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Added `removeUnusedCSS` option to enable removing rules from `style` elements whose class or ID selectors the document never references (requires `minifyCSS`, since removal runs through Lightning CSS):
-  - Symbols count as used when they appear in a `class` or `id` attribute, in an ID-referencing attribute (`for`, `headers`, `list`, `popovertarget`, `aria-controls`, and similar), anywhere in a `data-*` attribute value, or—unless `scripts` is set to `false`—anywhere inside an inline `script` element
-  - Class names only applied by external scripts cannot be detected; `safelist` accepts strings and regular expressions to keep them
-  - Names bound by `@keyframes` and `@counter-style` are not removed, even when no element carries them as a class or ID, as those at-rules are referenced from CSS rather than from markup
-  - Escaped identifiers (e.g., `.md\:flex`) are resolved before being matched against the markup
-  - A manually supplied `minifyCSS.unusedSymbols` list is merged with the computed one rather than replaced
+* Added `removeUnusedCSS` option to enable removing rules from `style` elements whose class or ID selectors the document never references (requires `minifyCSS`, since removal runs through Lightning CSS)
 * Added minifier diagnostics to `--verbose` (and `--dry`, which implies it)
-* Added reporting for CSS rules skipped under `errorRecovery`: With `continueOnMinifyError` enabled (the default), Lightning CSS skips invalid rules instead of throwing, which previously happened without any trace; the rules it drops are now reported through the `log` hook
+* Added reporting for invalid CSS under `errorRecovery`: With `continueOnMinifyError` enabled (the default), Lightning CSS reports invalid rules instead of throwing; it is reported through the `log` hook, once per document and for every document
+
+### Changed
+
+* Updated `minifyCSS`, `minifyJS`, and `minifySVG` to refuse a string value and report it instead of reading any non-empty string as “on”
 
 ## [7.5.3] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,7 +295,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-* `collapseBooleanAttributes` now collapses `crossorigin="anonymous"` to `crossorigin`, since “anonymous” is the attribute’s default value (previously only `crossorigin=""` was collapsed)
+* `collapseBooleanAttributes` now collapses `crossorigin="anonymous"` to `crossorigin`, since `anonymous` is the attribute’s default value (previously only `crossorigin=""` was collapsed)
 
 ## [5.1.5] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ As of version 2.0.0, all notable changes to HTML Minifier Next (HMN) are documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.6.0] - 2026-08-18
+
+### Added
+
+* Added `removeUnusedCSS` option to enable removing rules from `style` elements whose class or ID selectors the document never references (requires `minifyCSS`, since removal runs through Lightning CSS):
+  - Symbols count as used when they appear in a `class` or `id` attribute, in an ID-referencing attribute (`for`, `headers`, `list`, `popovertarget`, `aria-controls`, and similar), anywhere in a `data-*` attribute value, or—unless `scripts` is set to `false`—anywhere inside an inline `script` element
+  - Class names only applied by external scripts cannot be detected; `safelist` accepts strings and regular expressions to keep them
+  - Names bound by `@keyframes` and `@counter-style` are not removed, even when no element carries them as a class or ID, as those at-rules are referenced from CSS rather than from markup
+  - Escaped identifiers (e.g., `.md\:flex`) are resolved before being matched against the markup
+  - A manually supplied `minifyCSS.unusedSymbols` list is merged with the computed one rather than replaced
+
 ## [7.5.3] - 2026-08-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Names bound by `@keyframes` and `@counter-style` are not removed, even when no element carries them as a class or ID, as those at-rules are referenced from CSS rather than from markup
   - Escaped identifiers (e.g., `.md\:flex`) are resolved before being matched against the markup
   - A manually supplied `minifyCSS.unusedSymbols` list is merged with the computed one rather than replaced
+* Added minifier diagnostics to `--verbose` (and `--dry`, which implies it)
+* Added reporting for CSS rules skipped under `errorRecovery`: With `continueOnMinifyError` enabled (the default), Lightning CSS skips invalid rules instead of throwing, which previously happened without any trace; the rules it drops are now reported through the `log` hook
 
 ## [7.5.3] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-* Updated `minifyCSS`, `minifyJS`, and `minifySVG` to refuse a string value and report it instead of reading any non-empty string as “on”
+* Updated `minifyCSS`, `minifyJS`, and `minifySVG` to refuse a string value and report it instead of reading any non-empty string as “on”—pass `true` or an options object instead; config file and CLI values are unaffected where they parse as JSON, so `"true"` and `"false"` keep working
 
 ## [7.5.3] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Options can be used in config files (camelCase) or via CLI flags (kebab-case wit
 | `removeOptionalTags`<br>`--remove-optional-tags` | [Remove optional tags](https://perfectionkills.com/experimenting-with-html-minifier/#remove_optional_tags) | `false` |
 | `removeRedundantAttributes`<br>`--remove-redundant-attributes` | [Remove attributes when value matches default](https://meiert.com/blog/optional-html/#toc-attribute-values) | `false` |
 | `removeTagWhitespace`<br>`--remove-tag-whitespace` | Remove space between attributes whenever possible; **note that this will result in invalid HTML** | `false` |
+| `removeUnusedCSS`<br>`--remove-unused-css` | [Remove unused CSS rules](#unused-css-removal) from `style` elements; requires `minifyCSS`; **note that this can change how a document renders** | `false` (could be `true`, `{ safelist, scripts }`) |
 | `sortAttributes`<br>`--sort-attributes` | [Sort attributes by frequency](#sorting-attributes-and-style-classes) | `false` |
 | `sortClassNames`<br>`--sort-class-names` | [Sort style classes by frequency](#sorting-attributes-and-style-classes) | `false` |
 | `trimCustomFragments`<br>`--trim-custom-fragments` | Trim whitespace around custom fragments (`ignoreCustomFragments`) | `false` |
@@ -216,7 +217,7 @@ Available Lightning CSS options when passed as an object:
 
 * `targets`: Browser targets for vendor prefix optimization (e.g., `{ chrome: 95, firefox: 90 }`).
 * `unusedSymbols`: Array of class names, IDs, keyframe names, and CSS variables to remove.
-* `errorRecovery`: Boolean to skip invalid rules instead of throwing errors. This is disabled by default in Lightning CSS, but enabled in HMN when the `continueOnMinifyError` option is set to `true` (the default). Explicitly setting `errorRecovery` in `minifyCSS` options will override this automatic behavior.
+* `errorRecovery`: Boolean to skip invalid rules instead of throwing errors. This is disabled by default in Lightning CSS, but enabled in HMN when the `continueOnMinifyError` option is set to `true` (the default). Explicitly setting `errorRecovery` in `minifyCSS` options will override this automatic behavior. Rules skipped this way are reported through the [`log` hook](#api-only-options), so that a dropped rule does not go unnoticed.
 * `sourceMap`: Boolean to generate source maps.
 
 For advanced usage, you can also pass a function:
@@ -230,6 +231,39 @@ const result = await minify(html, {
   }
 });
 ```
+
+### Unused CSS removal
+
+`removeUnusedCSS` removes rules from `style` elements whose class or ID selectors the document doesn’t reference. It requires `minifyCSS`, because the removal runs through Lightning CSS. It does not touch `style` or `media` attributes.
+
+```js
+const result = await minify(html, {
+  minifyCSS: true,
+  removeUnusedCSS: true
+});
+```
+
+Symbols are considered used when they appear
+
+* in a `class` or `id` attribute,
+* in an attribute that references an ID (`for`, `headers`, `list`, `popovertarget`, `aria-controls`, and similar),
+* anywhere in a `data-*` attribute value, or
+* anywhere inside an inline `script` element, unless `scripts` is set to `false`.
+
+**Class names that only appear in external scripts cannot be detected.** A minifier sees one document, not the DOM that scripts later build from it, so a class added by `bundle.js` looks exactly like a class nobody uses. List those under `safelist`, as strings or regular expressions:
+
+```js
+const result = await minify(html, {
+  minifyCSS: true,
+  removeUnusedCSS: {
+    safelist: ['is-open', /^js-/],
+    // Set to `false` to also drop rules only referenced from inline scripts
+    scripts: true
+  }
+});
+```
+
+Names used by `@keyframes` and `@counter-style` rules are not removed, even when no element carries them as a class or ID, since those at-rules are referenced from CSS rather than from markup.
 
 ### JavaScript minification
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const result = await minify('<p title="example" id="moo">foo</p>', {
   removeAttributeQuotes: true,
   removeOptionalTags: true
 });
-console.log(result); // “<p title=example id=moo>foo”
+console.log(result); // `<p title=example id=moo>foo`
 ```
 
 See [the original blog post](https://perfectionkills.com/experimenting-with-html-minifier/) for details of [how it works](https://perfectionkills.com/experimenting-with-html-minifier/#how_it_works), [descriptions of most options](https://perfectionkills.com/experimenting-with-html-minifier/#options), [testing results](https://perfectionkills.com/experimenting-with-html-minifier/#field_testing), and [conclusions](https://perfectionkills.com/experimenting-with-html-minifier/#cost_and_benefits).
@@ -234,7 +234,7 @@ const result = await minify(html, {
 
 ### Unused CSS removal
 
-`removeUnusedCSS` removes rules from `style` elements whose class or ID selectors the document doesn’t reference. It requires `minifyCSS`, because the removal runs through Lightning CSS. It does not touch `style` or `media` attributes.
+`removeUnusedCSS` removes rules from `style` elements whose class or ID selectors the document doesn’t reference. It requires `minifyCSS`, because the removal runs through Lightning CSS—passing `minifyCSS` a function of your own replaces that step, so the removal does not apply, either. Both cases are reported through [the `log` hook](#api-only-options). It does not touch `style` or `media` attributes.
 
 ```js
 const result = await minify(html, {

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Available Lightning CSS options when passed as an object:
 
 * `targets`: Browser targets for vendor prefix optimization (e.g., `{ chrome: 95, firefox: 90 }`).
 * `unusedSymbols`: Array of class names, IDs, keyframe names, and CSS variables to remove.
-* `errorRecovery`: Boolean to skip invalid rules instead of throwing errors. This is disabled by default in Lightning CSS, but enabled in HMN when the `continueOnMinifyError` option is set to `true` (the default). Explicitly setting `errorRecovery` in `minifyCSS` options will override this automatic behavior. Rules skipped this way are reported through the [`log` hook](#api-only-options), so that a dropped rule does not go unnoticed.
+* `errorRecovery`: Boolean to skip invalid rules instead of throwing errors. This is disabled by default in Lightning CSS, but enabled in HMN when the `continueOnMinifyError` option is set to `true` (the default). Explicitly setting `errorRecovery` in `minifyCSS` options will override this automatic behavior. What Lightning CSS takes issue with is reported through [the `log` hook](#api-only-options)—it drops some of it (`@property` with an invalid `syntax`) and passes the rest through (an unknown at-rule), so that a dropped rule does not go unnoticed. Every document is reported on separately.
 * `sourceMap`: Boolean to generate source maps.
 
 For advanced usage, you can also pass a function:
@@ -247,8 +247,11 @@ Symbols are considered used when they appear
 
 * in a `class` or `id` attribute,
 * in an attribute that references an ID (`for`, `headers`, `list`, `popovertarget`, `aria-controls`, and similar),
+* in a same-document fragment URL, as `href="#main"`, `<use href="#icon">`, or `usemap="#map"`, and in a `url(#gradient)` reference from any attribute,
 * anywhere in a `data-*` attribute value, or
 * anywhere inside an inline `script` element, unless `scripts` is set to `false`.
+
+Names carrying characters that end a CSS identifier—`md:flex`, `w-1/2`, `p-[3px]`—are matched as whole tokens, so utility-CSS class names survive whether they come from markup, a `data-*` value, or a string in an inline script.
 
 **Class names that only appear in external scripts cannot be detected.** A minifier sees one document, not the DOM that scripts later build from it, so a class added by `bundle.js` looks exactly like a class nobody uses. List those under `safelist`, as strings or regular expressions:
 
@@ -264,6 +267,8 @@ const result = await minify(html, {
 ```
 
 Names used by `@keyframes` and `@counter-style` rules are not removed, even when no element carries them as a class or ID, since those at-rules are referenced from CSS rather than from markup.
+
+Values that cannot be honored—a `safelist` that isn’t an array, an entry that is neither a string nor a regular expression, a misspelled key—are reported through the `log` hook.
 
 ### JavaScript minification
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use `npx html-minifier-next --help` to check all available options:
 | `--file-ext <extensions>`, `-f <extensions>` | Specify file extension(s) to process (comma-separated, overrides config file setting); defaults to `html,htm,shtml,shtm`; use `*` for all files | `--file-ext=html,php`, `--file-ext='*'` |
 | `--preset <name>`, `-p <name>` | Use a preset configuration (conservative or comprehensive) | `--preset=conservative` |
 | `--config-file <file>`, `-c <file>` | Use a configuration file (defaults to html-minifier-next.config.json in the working directory, if present) | `--config-file=path/to/config.json` |
-| `--verbose`, `-v` | Show detailed processing information (active options, file statistics) | `npx html-minifier-next --input-dir=src --output-dir=dist --verbose --collapse-whitespace` |
+| `--verbose`, `-v` | Show detailed processing information (active options, file statistics, and minifier warnings) | `npx html-minifier-next --input-dir=src --output-dir=dist --verbose --collapse-whitespace` |
 | `--dry`, `-d` | Dry run: Process and report statistics without writing output | `npx html-minifier-next input.html --dry --collapse-whitespace` |
 
 ### Configuration file
@@ -187,7 +187,7 @@ A few options take functions and are therefore only available programmatically, 
 | --- | --- | --- |
 | `canCollapseWhitespace` | `Function(tag, attrs, defaultFn)` that determines whether whitespace inside an element can be collapsed—override to protect additional elements, delegating to `defaultFn` for the rest | Built-in handling (protects `pre`, `textarea`, etc.) |
 | `canTrimWhitespace` | `Function(tag, attrs, defaultFn)` that determines whether leading and trailing whitespace around an element may be trimmed | Built-in handling |
-| `log` | `Function(message)` called with warnings and errors, including minification errors swallowed by `continueOnMinifyError` (e.g., pass `console.error` to surface them) | No-op (errors are silent) |
+| `log` | `Function(message)` called with warnings and errors, including minification errors swallowed by `continueOnMinifyError` (e.g., pass `console.error` to surface them); the CLI wires this up under `--verbose` and `--dry` | No-op (errors are silent) |
 
 ### Sorting attributes and style classes
 

--- a/backtest/backtest.js
+++ b/backtest/backtest.js
@@ -14,12 +14,12 @@
 // checks out historical files, the working tree must have no uncommitted changes in
 // src, package.json, or html-minifier-next.config.json.
 //
-// Usage (from the “backtest” folder):
+// Usage (from the backtest folder):
 //   npm run backtest: Test the last 50 commits (default)
 //   npm run backtest 100: Test the last COUNT commits
 //   npm run backtest 500/10: Test the last COUNT commits, sampling every STEPth commit
 //
-// The corpus is downloaded on first run (sources listed in “sites.json”) and shared
+// The corpus is downloaded on first run (sources listed in sites.json) and shared
 // with `benchmark.js`.
 
 import { spawn, fork } from 'child_process';
@@ -236,7 +236,7 @@ async function minify(hash, options) {
         try {
           await fs.stat(pathFile);
         } catch {
-          throw new Error(`Source file not found: “${fileName}.html”`);
+          throw new Error(`Source file not found: ${fileName}.html`);
         }
 
         const data = await readText(pathFile);
@@ -391,7 +391,7 @@ if (process.argv.length > 2 || !process.send) {
       const parts = arg.split('/');
       if (parts.length !== 2) {
         console.error(`Error: Invalid format “${arg}”—use “COUNT” or “COUNT/STEP”`);
-        console.error(`Examples: “backtest.js 50” or “backtest.js 500/10”`);
+        console.error('Examples: `backtest.js 50` or `backtest.js 500/10`');
         process.exit(1);
       }
 
@@ -410,12 +410,12 @@ if (process.argv.length > 2 || !process.send) {
       count = parseInt(arg, 10);
       if (!Number.isInteger(count) || count < 1) {
         console.error(`Error: Invalid commit count “${arg}”—must be a positive integer`);
-        console.error(`Example: “backtest.js 50”`);
+        console.error('Example: `backtest.js 50`');
         process.exit(1);
       }
     }
   } else {
-    console.log(`Running backtest on last ${DEFAULT_COMMIT_COUNT} commits (use: “backtest.js COUNT” to specify)`);
+    console.log(`Running backtest on last ${DEFAULT_COMMIT_COUNT} commits (use: \`backtest.js COUNT\` to specify)`);
   }
 
   if (count > 0) {
@@ -460,7 +460,7 @@ if (process.argv.length > 2 || !process.send) {
           console.log(`\nCleaning up after ${reason}…`);
         }
 
-        // Restore “src” folder, package.json, and html-minifier-next.config.json from HEAD using Git
+        // Restore src folder, package.json, and html-minifier-next.config.json from HEAD using Git
         await new Promise((resolve) => {
           git('checkout', 'HEAD', '--', pathSrc, pathConfig, pathPkg, function (code) {
             if (code !== 0) {

--- a/backtest/backtest.js
+++ b/backtest/backtest.js
@@ -390,7 +390,7 @@ if (process.argv.length > 2 || !process.send) {
     if (arg.includes('/')) {
       const parts = arg.split('/');
       if (parts.length !== 2) {
-        console.error(`Error: Invalid format “${arg}”—use “COUNT” or “COUNT/STEP”`);
+        console.error(`Error: Invalid format “${arg}”—use \`COUNT\` or \`COUNT/STEP\``);
         console.error('Examples: `backtest.js 50` or `backtest.js 500/10`');
         process.exit(1);
       }

--- a/backtest/benchmark.js
+++ b/backtest/benchmark.js
@@ -7,7 +7,7 @@
 // Unlike `backtest.js` (which walks Git history), this measures the code exactly as
 // it is right now—ideal for A/B testing a branch against a saved baseline.
 //
-// Usage (from the “backtest” folder):
+// Usage (from the backtest folder):
 //   npm run benchmark: Run; if a baseline exists, show deltas
 //   npm run benchmark -- --save: Run and save the result as the baseline
 //   npm run benchmark -- --core: Disable external minifiers (CSS/JS/SVG/URLs) to isolate HMN’s own processing time
@@ -167,7 +167,7 @@ async function main() {
     try {
       data = await fs.readFile(pathFile, 'utf8');
     } catch {
-      console.error(`Skipping “${fileName}”: input not found (run “npm run backtest” once to download the corpus)`);
+      console.error(`Skipping ${fileName}: input not found (run \`npm run backtest\` once to download the corpus)`);
       continue;
     }
 
@@ -209,7 +209,7 @@ async function main() {
   }
 
   if (!processed) {
-    console.error('\nNo input files found. Run “npm run backtest” once to download the corpus.');
+    console.error('\nNo input files found. Run `npm run backtest` once to download the corpus.');
     process.exit(1);
   }
 

--- a/cli.js
+++ b/cli.js
@@ -244,7 +244,7 @@ function normalizeConfig(config) {
   // Warn about unrecognized config keys—catches typos as well as options removed in earlier versions
   Object.keys(normalized).forEach(function (key) {
     if (!Object.hasOwn(optionDefinitions, key) && !CONFIG_KEYS_EXTRA.has(key)) {
-      console.error(`Ignoring unknown or deprecated config option “${key}” (see \`--help\` or README for available options)`);
+      console.error(`Ignoring unknown or deprecated config option \`${key}\` (see \`--help\` or README for available options)`);
     }
   });
 
@@ -282,9 +282,9 @@ function normalizeConfig(config) {
 let config = {};
 program.option('-z, --zero', 'Minify all HTML files in the current folder and its subfolders in place (except node_modules), using comprehensive settings (standalone—flag is ignored when combined with other options)');
 program.option('-I --input-dir <dir>', 'Specify an input directory');
-program.option('-X --ignore-dir <patterns>', 'Exclude directories—relative to input directory—from processing (comma-separated), e.g., “libs” or “libs,vendor,node_modules”');
+program.option('-X --ignore-dir <patterns>', 'Exclude directories—relative to input directory—from processing (comma-separated), e.g., `libs` or `libs,vendor,node_modules`');
 program.option('-O --output-dir <dir>', 'Specify an output directory');
-program.option('-f --file-ext <extensions>', 'Specify file extension(s) to process (comma-separated); defaults to “html,htm,shtml,shtm”; use “*” for all files');
+program.option('-f --file-ext <extensions>', 'Specify file extension(s) to process (comma-separated); defaults to `html,htm,shtml,shtm`; use `*` for all files');
 program.option('-p --preset <name>', `Use a preset configuration (${getPresetNames().join(', ')})`);
 program.option('-c --config-file <file>', 'Use config file');
 program.version(pkg.version, '-V, --version', 'Output the version number');
@@ -399,7 +399,7 @@ program.helpOption('-h, --help', 'Display help for command');
   } else {
     const configFileDefault = CONFIG_FILES_DEFAULT.find(name => fs.existsSync(path.resolve(name)));
     if (configFileDefault) {
-      console.error(`Using config file “${configFileDefault}”`);
+      console.error(`Using config file ${configFileDefault}`);
       config = normalizeConfig(await loadConfigFromPath(configFileDefault));
     }
   }
@@ -445,7 +445,7 @@ program.helpOption('-h, --help', 'Display help for command');
         // offending content unminified—so say that
         if (message instanceof Error) {
           console.error(`  ${MARK_WARNING}Warning: Minification failed, content left as-is: ${message.message || message}${MARK_RESET}`);
-        } else if (String(message).startsWith('Warning: ')) {
+        } else if (String(message).startsWith('Warning: ') || String(message).startsWith('HTML Minifier Next: ')) {
           console.error(`  ${MARK_WARNING}${message}${MARK_RESET}`);
         } else {
           console.error(`  ${message}`);
@@ -896,7 +896,7 @@ program.helpOption('-h, --help', 'Display help for command');
     for (const file of capturedFiles) {
       const ext = path.extname(file).replace(/^\./, '').toLowerCase();
       if (EXTENSIONS_NON_HTML.has(ext)) {
-        console.error(`${MARK_WARNING}Warning: “${path.basename(file)}” does not appear to be an HTML file—HTML Minifier Next processes CSS, JavaScript, and SVG only when embedded in HTML. The output may be incomplete or broken.${MARK_RESET}`);
+        console.error(`${MARK_WARNING}Warning: ${path.basename(file)} does not appear to be an HTML file—HTML Minifier Next processes CSS, JavaScript, and SVG only when embedded in HTML. The output may be incomplete or broken.${MARK_RESET}`);
       }
     }
 

--- a/cli.js
+++ b/cli.js
@@ -438,6 +438,21 @@ program.helpOption('-h, --help', 'Display help for command');
       }
     });
 
+    // 4. Surface minifier diagnostics when verbose
+    if (programOptions.verbose || programOptions.dry) {
+      options.log = message => {
+        // Only `continueOnMinifyError` passes `Error` objects, always after leaving the
+        // offending content unminified—so say that
+        if (message instanceof Error) {
+          console.error(`  ${MARK_WARNING}Warning: Minification failed, content left as-is: ${message.message || message}${MARK_RESET}`);
+        } else if (String(message).startsWith('Warning: ')) {
+          console.error(`  ${MARK_WARNING}${message}${MARK_RESET}`);
+        } else {
+          console.error(`  ${message}`);
+        }
+      };
+    }
+
     return options;
   }
 

--- a/cli.js
+++ b/cli.js
@@ -141,6 +141,7 @@ const typeParsers = {
   regexp: parseRegExp,
   regexpArray: parseJSONRegExpArray,
   json: parseJSON,
+  jsonObject: parseJSON,
   jsonArray: parseJSONArray,
   string: parseString,
   int: (key) => parseValidInt(key)
@@ -165,7 +166,7 @@ mainOptionKeys.forEach(function (key) {
       program.addOption(new Option('--no-' + flag, 'Disable --' + flag).hideHelp());
     }
   } else {
-    const cliFlag = '--' + flag + (type === 'json' ? ' [value]' : ' <value>');
+    const cliFlag = '--' + flag + (type === 'json' || type === 'jsonObject' ? ' [value]' : ' <value>');
     const parser = type === 'int' ? typeParsers.int(key) : typeParsers[type];
     program.option(cliFlag, description, parser);
   }

--- a/cli.js
+++ b/cli.js
@@ -442,6 +442,11 @@ program.helpOption('-h, --help', 'Display help for command');
     // 4. Surface minifier diagnostics when verbose
     if (programOptions.verbose || programOptions.dry) {
       options.log = message => {
+        // The hook carries the minifier’s per-call timing as well, which the run's own
+        // per-file statistics already cover
+        if (typeof message === 'string' && message.startsWith('minified in: ')) {
+          return;
+        }
         // Only `continueOnMinifyError` passes `Error` objects, always after leaving the
         // offending content unminified—so say that
         if (message instanceof Error) {

--- a/demo/default.js
+++ b/demo/default.js
@@ -159,6 +159,13 @@ const demoConfig = {
     label: 'Remove tag whitespace',
     unsafe: true
   },
+  removeUnusedCSS: {
+    label: 'Remove unused CSS',
+    checked: false,
+    disabled: true,
+    unsafe: true,
+    helpText: 'Remove rules from <code>style</code> elements whose class or ID selectors the document never references (if CSS is to be minified; disabled in web demo because it requires Node.js)'
+  },
   sortAttributes: {
     label: 'Sort attributes',
     unsafe: true

--- a/html-minifier-next.schema.json
+++ b/html-minifier-next.schema.json
@@ -182,7 +182,6 @@
       "description": "Minify CSS in `style` elements and attributes (uses Lightning CSS)",
       "type": [
         "boolean",
-        "string",
         "object"
       ]
     },
@@ -190,7 +189,6 @@
       "description": "Minify JavaScript in `script` elements and event attributes (uses Terser or SWC; pass `{\"engine\": \"swc\"}` for SWC)",
       "type": [
         "boolean",
-        "string",
         "object"
       ]
     },
@@ -198,7 +196,6 @@
       "description": "Minify SVG elements (uses SVGO)",
       "type": [
         "boolean",
-        "string",
         "object"
       ]
     },
@@ -286,7 +283,6 @@
       "description": "Remove rules from `style` elements whose class or ID selectors the document never references (requires `--minify-css`); note that class names only applied by external scripts cannot be detected—use `{\"safelist\": […]}` for those",
       "type": [
         "boolean",
-        "string",
         "object"
       ]
     },

--- a/html-minifier-next.schema.json
+++ b/html-minifier-next.schema.json
@@ -282,6 +282,14 @@
       "description": "Remove space between attributes whenever possible; note that this will result in invalid HTML",
       "type": "boolean"
     },
+    "removeUnusedCSS": {
+      "description": "Remove rules from `style` elements whose class or ID selectors the document never references (requires `--minify-css`); note that class names only applied by external scripts cannot be detected—use `{\"safelist\": […]}` for those",
+      "type": [
+        "boolean",
+        "string",
+        "object"
+      ]
+    },
     "sortAttributes": {
       "description": "Sort attributes by frequency",
       "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -95,5 +95,5 @@
   },
   "type": "module",
   "types": "dist/types/htmlminifier.d.ts",
-  "version": "7.5.3"
+  "version": "7.6.0"
 }

--- a/scripts/build-schema.js
+++ b/scripts/build-schema.js
@@ -20,6 +20,7 @@ const typeSchemas = {
   regexp: { type: 'string' },
   regexpArray: { type: ['string', 'array'], items: { type: 'string' } },
   json: { type: ['boolean', 'string', 'object'] },
+  jsonObject: { type: ['boolean', 'object'] },
   jsonArray: { type: ['string', 'array'], items: { type: 'string' } }
 };
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1107,13 +1107,13 @@ async function minifyHTML(value, options, partialMarkup) {
 
           if (options.minifyCSS !== identity) {
             options.minifyCSS = (function (/** @type {ProcessedOptions['minifyCSS']} */ fn) {
-              return function (/** @type {string} */ text, /** @type {string | undefined} */ type) {
+              return function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {Set<string> | undefined} */ usedSymbols) {
                 text = text.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ _match, /** @type {string} */ _prefix, /** @type {string} */ index) {
                   const chunks = ignoredCustomMarkupChunks[+index];
                   return (chunks?.[1] ?? '') + uidAttr + index + uidAttr + (chunks?.[2] ?? '');
                 });
 
-                return fn(text, type);
+                return fn(text, type, usedSymbols);
               };
             })(options.minifyCSS);
           }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -2113,7 +2113,13 @@ export const minify = async function (value, options) {
   // Unused-CSS removal needs the whole document’s symbols before the first `style`
   // element is minified, so collect them upfront from the raw input
   if (processedOptions.removeUnusedCSS && processedOptions.minifyCSS !== identity) {
-    processedOptions.usedCSSSymbols = collectUsedSymbols(value, processedOptions.removeUnusedCSS.scripts);
+    processedOptions.usedCSSSymbols = collectUsedSymbols(
+      value,
+      processedOptions.removeUnusedCSS.scripts,
+      value.indexOf('&') !== -1
+        ? /** @type {(text: string) => string} */ (await getDecodeHTML())
+        : undefined
+    );
   }
 
   let result = await minifyHTML(value, processedOptions);

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -2112,7 +2112,7 @@ export const minify = async function (value, options) {
 
   // Unused-CSS removal needs the whole document’s symbols before the first `style`
   // element is minified, so collect them upfront from the raw input
-  if (processedOptions.removeUnusedCSS && processedOptions.minifyCSS !== identity) {
+  if (processedOptions.removeUnusedCSS) {
     processedOptions.usedCSSSymbols = collectUsedSymbols(
       value,
       processedOptions.removeUnusedCSS.scripts,

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -8,6 +8,7 @@ import { collectUsedSymbols } from './lib/unused-css.js';
 import {
   RE_LEGACY_ENTITIES,
   RE_ESCAPE_LT,
+  RE_STYLE_ELEMENT,
   inlineElementsToKeepWhitespaceAround,
   inlineElementsToKeepWhitespaceWithin,
   specialContentElements,
@@ -1107,13 +1108,13 @@ async function minifyHTML(value, options, partialMarkup) {
 
           if (options.minifyCSS !== identity) {
             options.minifyCSS = (function (/** @type {ProcessedOptions['minifyCSS']} */ fn) {
-              return function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {Set<string> | undefined} */ usedSymbols) {
+              return function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {ProcessedOptions['cssContext']} */ context) {
                 text = text.replace(/** @type {RegExp} */ (uidPattern), function (/** @type {string} */ _match, /** @type {string} */ _prefix, /** @type {string} */ index) {
                   const chunks = ignoredCustomMarkupChunks[+index];
                   return (chunks?.[1] ?? '') + uidAttr + index + uidAttr + (chunks?.[2] ?? '');
                 });
 
-                return fn(text, type, usedSymbols);
+                return fn(text, type, context);
               };
             })(options.minifyCSS);
           }
@@ -1773,7 +1774,7 @@ async function minifyHTML(value, options, partialMarkup) {
           text = await options.minifyJS(text, false, isModuleScript);
         }
         if (needsMinifyCSS) {
-          text = await options.minifyCSS(text, undefined, options.usedCSSSymbols);
+          text = await options.minifyCSS(text, undefined, options.cssContext);
         }
         charsFinalize(text);
       })();
@@ -2110,10 +2111,16 @@ export const minify = async function (value, options) {
   // Work on a shallow copy so per-call reassignments don’t reach the cached base
   const processedOptions = /** @type {ProcessedOptions} */ ({ ...processedBase });
 
+  // Warnings are deduplicated per document, so the state has to live on the per-call
+  // copy; the `minifyCSS` closure hangs off the memoized base, shared across calls
+  processedOptions.cssContext = { warned: new Set() };
+
   // Unused-CSS removal needs the whole document’s symbols before the first `style`
-  // element is minified, so collect them upfront from the raw input
-  if (processedOptions.removeUnusedCSS) {
-    processedOptions.usedCSSSymbols = collectUsedSymbols(
+  // element is minified, so collect them upfront from the raw input. A document
+  // without a style sheet has nothing to remove from, and scanning it would be work
+  // spent on an empty result.
+  if (processedOptions.removeUnusedCSS && RE_STYLE_ELEMENT.test(value)) {
+    processedOptions.cssContext.usedSymbols = collectUsedSymbols(
       value,
       processedOptions.removeUnusedCSS.scripts,
       value.indexOf('&') !== -1

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -3,6 +3,7 @@ import TokenChain from './tokenchain.js';
 import { presets, getPreset, getPresetNames } from './presets.js';
 
 import { LRU, identity, isThenable, lowercase, uniqueId } from './lib/utils.js';
+import { collectUsedSymbols } from './lib/unused-css.js';
 
 import {
   RE_LEGACY_ENTITIES,
@@ -434,6 +435,20 @@ import { processOptions } from './lib/options.js';
  *  When true, extra whitespace between tag name and attributes (or before
  *  the closing bracket) will be removed where possible. Affects output spacing
  *  such as the space used in the short doctype representation.
+ *
+ *  Default: `false`
+ *
+ * @prop {boolean | {safelist?: Array<string | RegExp>, scripts?: boolean}} [removeUnusedCSS]
+ *  **Note that this can change how a document renders!**
+ *
+ *  Remove rules from `style` elements whose class or ID selectors the document
+ *  never references. Requires `minifyCSS` (removal runs through Lightning CSS)
+ *  and has no effect on `style` or `media` attributes.
+ *
+ *  Class names and IDs are collected from the markup, from `data-*` attributes,
+ *  and—unless `scripts` is set to `false`—from inline `script` elements. Names
+ *  that only ever appear in external scripts cannot be detected; list those
+ *  under `safelist` (strings or regular expressions) to keep them.
  *
  *  Default: `false`
  *
@@ -1758,7 +1773,7 @@ async function minifyHTML(value, options, partialMarkup) {
           text = await options.minifyJS(text, false, isModuleScript);
         }
         if (needsMinifyCSS) {
-          text = await options.minifyCSS(text);
+          text = await options.minifyCSS(text, undefined, options.usedCSSSymbols);
         }
         charsFinalize(text);
       })();
@@ -2094,6 +2109,13 @@ export const minify = async function (value, options) {
   }
   // Work on a shallow copy so per-call reassignments don’t reach the cached base
   const processedOptions = /** @type {ProcessedOptions} */ ({ ...processedBase });
+
+  // Unused-CSS removal needs the whole document’s symbols before the first `style`
+  // element is minified, so collect them upfront from the raw input
+  if (processedOptions.removeUnusedCSS && processedOptions.minifyCSS !== identity) {
+    processedOptions.usedCSSSymbols = collectUsedSymbols(value, processedOptions.removeUnusedCSS.scripts);
+  }
+
   let result = await minifyHTML(value, processedOptions);
 
   // Post-processing: Merge consecutive inline scripts if enabled

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -2,7 +2,7 @@ import { HTMLParser, endTag } from './htmlparser.js';
 import TokenChain from './tokenchain.js';
 import { presets, getPreset, getPresetNames } from './presets.js';
 
-import { LRU, identity, isThenable, lowercase, uniqueId } from './lib/utils.js';
+import { LRU, findTagEnd, identity, isThenable, lowercase, uniqueId } from './lib/utils.js';
 import { collectUsedSymbols } from './lib/unused-css.js';
 
 import {
@@ -585,28 +585,6 @@ const RE_HTML_ENCODING = /^(text\/html|application\/xhtml\+xml)$/i;
 const RE_FOREIGN_ELEMENT_PROBE = /<(?:svg|math)[\s/>]/i;
 
 // Script merging
-
-/**
- * Find the index of the `>` that closes an opening tag, correctly skipping
- * over quoted attribute values (which may contain `>`).
- * @param {string} html
- * @param {number} pos - Start position (just after the tag name)
- * @returns {number} Index of the closing `>`, or -1 if not found
- */
-function findTagEnd(html, pos) {
-  let i = pos;
-  while (i < html.length) {
-    const ch = html[i];
-    if (ch === '>') return i;
-    if (ch === '"' || ch === "'") {
-      const q = ch;
-      i++;
-      while (i < html.length && html[i] !== q) i++;
-    }
-    i++;
-  }
-  return -1;
-}
 
 /**
  * Merge consecutive inline script tags into one (`mergeConsecutiveScripts`).

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -470,7 +470,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
         attrValue = attrValue.replace(/\s*;$/, ';');
       }
       const originalAttrValue = attrValue;
-      const cssResult = options.minifyCSS(attrValue, 'inline');
+      const cssResult = options.minifyCSS(attrValue, 'inline', options.cssContext);
       if (isThenable(cssResult)) {
         return cssResult
           .then((/** @type {string} */ minified) => {
@@ -581,7 +581,7 @@ function cleanAttributeValue(tag, attrName, attrValue, options, attrs, minifyHTM
       return attrValue;
     }
     const originalAttrValue = attrValue;
-    const cssResult = options.minifyCSS(attrValue, 'media');
+    const cssResult = options.minifyCSS(attrValue, 'media', options.cssContext);
     if (isThenable(cssResult)) {
       return cssResult.catch((/** @type {Error} */ err) => {
         if (!options.continueOnMinifyError) throw err;

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -16,6 +16,7 @@ const RE_ESCAPE_LT = /</g;
 const RE_ATTR_WS_CHECK = /[ \n\r\t\f]/;
 const RE_ATTR_WS_COLLAPSE = /[ \n\r\t\f]+/g;
 const RE_ATTR_WS_TRIM = /^[ \n\r\t\f]+|[ \n\r\t\f]+$/g;
+const RE_STYLE_ELEMENT = /<style[\s/>]/i;
 
 // Inline element sets for whitespace handling
 
@@ -192,6 +193,7 @@ export {
   RE_ATTR_WS_CHECK,
   RE_ATTR_WS_COLLAPSE,
   RE_ATTR_WS_TRIM,
+  RE_STYLE_ELEMENT,
   // Inline element sets
   inlineElementsToKeepWhitespaceAround,
   inlineElementsToKeepWhitespaceWithin,

--- a/src/lib/elements.js
+++ b/src/lib/elements.js
@@ -137,7 +137,7 @@ function canRemoveElement(tag, attrs) {
 }
 
 /**
- * @param {string} str - Tag name or HTML-like element spec (e.g., “td” or “<span aria-hidden='true'>”)
+ * @param {string} str - Tag name or HTML-like element spec (e.g., `td` or `<span aria-hidden='true'>`)
  * @param {ProcessedOptions} options - Options object for name normalization
  * @returns {{tag: string, attrs: Object.<string, string|undefined>|null}|null} Parsed spec or null if invalid
  */
@@ -203,12 +203,12 @@ function parseRemoveEmptyElementsExcept(input, options) {
     if (typeof item === 'string') {
       const spec = parseElementSpec(item, options);
       if (!spec && options.log) {
-        options.log('Warning: Unable to parse “removeEmptyElementsExcept” specification: “' + item + '”');
+        options.log('Warning: Unable to parse `removeEmptyElementsExcept` specification: “' + item + '”');
       }
       return spec;
     }
     if (options.log) {
-      options.log('Warning: “removeEmptyElementsExcept” specification must be a string, received: ' + typeof item);
+      options.log('Warning: `removeEmptyElementsExcept` specification must be a string, received: ' + typeof item);
     }
     return null;
   }).filter(Boolean));

--- a/src/lib/option-definitions.js
+++ b/src/lib/option-definitions.js
@@ -178,6 +178,10 @@ const optionDefinitions = {
     description: 'Remove space between attributes whenever possible; note that this will result in invalid HTML',
     type: 'boolean'
   },
+  removeUnusedCSS: {
+    description: 'Remove rules from `style` elements whose class or ID selectors the document never references (requires `--minify-css`); note that class names only applied by external scripts cannot be detected—use `{"safelist": […]}` for those',
+    type: 'json'
+  },
   sortAttributes: {
     description: 'Sort attributes by frequency',
     type: 'boolean'

--- a/src/lib/option-definitions.js
+++ b/src/lib/option-definitions.js
@@ -104,15 +104,15 @@ const optionDefinitions = {
   },
   minifyCSS: {
     description: 'Minify CSS in `style` elements and attributes (uses Lightning CSS)',
-    type: 'json'
+    type: 'jsonObject'
   },
   minifyJS: {
     description: 'Minify JavaScript in `script` elements and event attributes (uses Terser or SWC; pass `{"engine": "swc"}` for SWC)',
-    type: 'json'
+    type: 'jsonObject'
   },
   minifySVG: {
     description: 'Minify SVG elements (uses SVGO)',
-    type: 'json'
+    type: 'jsonObject'
   },
   minifyURLs: {
     description: 'Minify URLs in various attributes',
@@ -180,7 +180,7 @@ const optionDefinitions = {
   },
   removeUnusedCSS: {
     description: 'Remove rules from `style` elements whose class or ID selectors the document never references (requires `--minify-css`); note that class names only applied by external scripts cannot be detected—use `{"safelist": […]}` for those',
-    type: 'json'
+    type: 'jsonObject'
   },
   sortAttributes: {
     description: 'Sort attributes by frequency',

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -12,6 +12,21 @@ import { optionDefinitions, optionDefaults } from './option-definitions.js';
 // Type definitions
 
 /**
+ * Per-document state handed to `minifyCSS`. Its closure hangs off the memoized
+ * options object that every `minify()` call with those options shares, so state
+ * belonging to one document has to be passed in rather than captured.
+ *
+ * @typedef {{usedSymbols?: Set<string>, warned: Set<string>}} CSSContext
+ */
+
+/**
+ * Minified style sheet plus the warnings its transform produced, cached together
+ * so that a cache hit can report what the transform reported
+ *
+ * @typedef {{css: string, warnings: string[]}} CSSResult
+ */
+
+/**
  * Options object produced by `processOptions` and consumed by `minifyHTML` and
  * the `lib/` helpers; normalization guarantees that the function-valued options
  * below are always present (defaulting to identity/built-in functions), and
@@ -24,12 +39,12 @@ import { optionDefinitions, optionDefaults } from './option-definitions.js';
  *   ignoreCustomComments: RegExp[],
  *   canCollapseWhitespace: (tag: string, attrs: HTMLAttribute[], defaultFn: (tag: string) => boolean) => boolean,
  *   canTrimWhitespace: (tag: string, attrs: HTMLAttribute[], defaultFn: (tag: string) => boolean) => boolean,
- *   minifyCSS: (text: string, type?: string, usedSymbols?: Set<string>) => string | Promise<string>,
+ *   minifyCSS: (text: string, type?: string, context?: CSSContext) => string | Promise<string>,
  *   minifyJS: (text: string, inline?: boolean, isModule?: boolean) => string | Promise<string>,
  *   minifyURLs: (text: string) => string | Promise<string>,
  *   minifySVG: ((svgContent: string) => string | Promise<string>) | null,
  *   removeUnusedCSS: {safelist: Array<string | RegExp>, scripts: boolean} | null,
- *   usedCSSSymbols?: Set<string>,
+ *   cssContext?: CSSContext,
  *   nameParent?: (name: string) => string,
  *   nameHTML?: (name: string) => string,
  *   insideSVG?: boolean,
@@ -86,8 +101,8 @@ const presetNamesWarned = new Set();
 // console even without a `log` hook—once per process, like the warnings above
 let customFragmentQuantifierWarned = false;
 const unusedCSSWarned = new Set();
-// Invalid CSS reported by Lightning CSS, warned about once per distinct problem
-const cssWarned = new Set();
+// Object-valued options handed a string, warned about once per distinct value
+const stringValuesWarned = new Set();
 
 // Main options processor
 
@@ -173,12 +188,30 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       return;
     }
 
+    // A string carries no configuration for these options. The CLI parses config
+    // values as JSON first, so only a value that is not JSON reaches this from
+    // there. (`minifyURLs` is deliberately excluded—there, a string names the site.)
+    const definition = /** @type {Record<string, {type?: string}>} */ (optionDefinitions)[key];
+    if (typeof option === 'string' && definition?.type === 'jsonObject') {
+      const message = `HTML Minifier Next: Ignoring \`${key}\`—it takes a boolean or an object, not a string (“${option}”)`;
+      if (!stringValuesWarned.has(message)) {
+        stringValuesWarned.add(message);
+        warn(message);
+      }
+      return;
+    }
+
     if (key === 'caseSensitive') {
       if (option) {
         options.name = identity;
       }
     } else if (key === 'removeUnusedCSS') {
-      optionsDynamic.removeUnusedCSS = normalizeUnusedCSSOptions(option);
+      optionsDynamic.removeUnusedCSS = normalizeUnusedCSSOptions(option, message => {
+        if (!unusedCSSWarned.has(message)) {
+          unusedCSSWarned.add(message);
+          warn(`HTML Minifier Next: ${message}`);
+        }
+      });
     } else if (key === 'log') {
       if (typeof option === 'function') {
         options.log = option;
@@ -193,11 +226,32 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       const cssLoader = getLightningCSS;
       const cssCache = cssMinifyCache;
 
-      options.minifyCSS = async function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {Set<string> | undefined} */ usedSymbols) {
+      options.minifyCSS = async function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {CSSContext | undefined} */ context) {
         // Fast path: Nothing to minify
         if (!text || !text.trim()) {
           return text;
         }
+
+        // Warnings are stored with the minified result and replayed on every hit, so a
+        // second document with the same defect hears about it, too; `context.warned`
+        // then keeps one document from repeating itself. Reporting from the cache
+        // rather than only from the transform keeps the output independent of cache
+        // size and eviction.
+        const report = (/** @type {string[]} */ messages) => {
+          if (!messages.length || options.log === identity) {
+            return;
+          }
+          const warned = context?.warned;
+          for (const message of messages) {
+            if (warned) {
+              if (warned.has(message)) {
+                continue;
+              }
+              warned.add(message);
+            }
+            options.log(message);
+          }
+        };
 
         // Optimization: Only process URLs if minification is enabled (not identity function)
         // This avoids expensive `replaceAsync` when URL minification is disabled
@@ -224,8 +278,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
         // Unused-symbol removal applies to style sheets only
         const unusedCSSConfig = type === undefined ? options.removeUnusedCSS : undefined;
-        const unusedSymbols = (unusedCSSConfig && usedSymbols)
-          ? findUnusedSymbols(text, usedSymbols, unusedCSSConfig.safelist)
+        const unusedSymbols = (unusedCSSConfig && context?.usedSymbols)
+          ? findUnusedSymbols(text, context.usedSymbols, unusedCSSConfig.safelist)
           : undefined;
 
         // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys.
@@ -247,10 +301,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
         try {
           if (cssKey !== undefined) {
-            const cached = /** @type {string | Promise<string> | undefined} */ (cssCache.get(cssKey));
+            const cached = /** @type {CSSResult | Promise<CSSResult> | undefined} */ (cssCache.get(cssKey));
             if (cached !== undefined) {
               // Support both resolved values and in-flight promises
-              return await cached;
+              const settled = await cached;
+              report(settled.warnings);
+              return settled.css;
             }
           }
 
@@ -271,19 +327,16 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
                 : {})
             });
 
-            // With `errorRecovery` enabled, Lightning CSS skips invalid rules instead of
-            // throwing, and reports each one here; surfacing them keeps a dropped rule
-            // from vanishing without a trace. Deduplicating on the warning itself rather
-            // than leaving it to the cache keeps batch runs quiet without making the
-            // output depend on cache size or eviction.
-            if (options.log !== identity && result.warnings && result.warnings.length) {
+            // With `errorRecovery` enabled, Lightning CSS reports what it takes issue
+            // with instead of throwing—dropping the rule in some cases (`@property`
+            // with a bad `syntax`) and passing it through in others (an unknown
+            // at-rule), which is why the wording stops at “reported”
+            /** @type {string[]} */
+            const warnings = [];
+            if (result.warnings) {
               for (const warning of result.warnings) {
                 const at = warning.loc ? ` (line ${warning.loc.line}, column ${warning.loc.column})` : '';
-                const message = `Warning: Lightning CSS skipped invalid CSS${at}: ${warning.message}`;
-                if (!cssWarned.has(message)) {
-                  cssWarned.add(message);
-                  options.log(message);
-                }
+                warnings.push(`Warning: Lightning CSS reported invalid CSS${at}: ${warning.message}`);
               }
             }
 
@@ -301,13 +354,15 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
             // Preserve if output is empty and input had template syntax or UIDs
             // This catches cases where Lightning CSS removed content that should be preserved
-            return (text.trim() && !outputCSS.trim() && (looksLikeTemplate || hasUID)) ? text : outputCSS;
+            const css = (text.trim() && !outputCSS.trim() && (looksLikeTemplate || hasUID)) ? text : outputCSS;
+            return { css, warnings };
           })();
 
           if (cssKey !== undefined) cssCache.set(cssKey, inFlight);
           const resolved = await inFlight;
           if (cssKey !== undefined) cssCache.set(cssKey, resolved);
-          return resolved;
+          report(resolved.warnings);
+          return resolved.css;
         } catch (err) {
           if (cssKey !== undefined) cssCache.delete(cssKey);
           if (!options.continueOnMinifyError) {
@@ -562,13 +617,9 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
   // when `minifyCSS` is off or replaced by a function—say so rather than let it pass
   if (options.removeUnusedCSS) {
     const cssOption = /** @type {Record<string, any>} */ (effectiveInput).minifyCSS;
-    // A string carries no meaning here, and treating one as “on” would let
-    // `"false"` in a configuration file delete rules the document still needs
-    const reason = typeof (/** @type {Record<string, any>} */ (effectiveInput).removeUnusedCSS) === 'string'
-      ? 'it takes a boolean or an object, not a string'
-      : typeof cssOption === 'function'
-        ? 'it does not apply when `minifyCSS` is a function'
-        : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
+    const reason = typeof cssOption === 'function'
+      ? 'it does not apply when `minifyCSS` is a function'
+      : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
     if (reason) {
       if (!unusedCSSWarned.has(reason)) {
         unusedCSSWarned.add(reason);

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -562,9 +562,13 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
   // when `minifyCSS` is off or replaced by a function—say so rather than let it pass
   if (options.removeUnusedCSS) {
     const cssOption = /** @type {Record<string, any>} */ (effectiveInput).minifyCSS;
-    const reason = typeof cssOption === 'function'
-      ? 'it does not apply when `minifyCSS` is a function'
-      : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
+    // A string carries no meaning here, and treating one as “on” would let
+    // `"false"` in a configuration file delete rules the document still needs
+    const reason = typeof (/** @type {Record<string, any>} */ (effectiveInput).removeUnusedCSS) === 'string'
+      ? 'it takes a boolean or an object, not a string'
+      : typeof cssOption === 'function'
+        ? 'it does not apply when `minifyCSS` is a function'
+        : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
     if (reason) {
       if (!unusedCSSWarned.has(reason)) {
         unusedCSSWarned.add(reason);

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -3,6 +3,7 @@ import { LRU, MAX_CACHE_ENTRY_SIZE, stableStringify, hashContent, identity, lowe
 import { RE_TRAILING_SEMICOLON } from './constants.js';
 import { canCollapseWhitespace, canTrimWhitespace } from './whitespace.js';
 import { wrapCSS, unwrapCSS } from './content.js';
+import { findUnusedSymbols, normalizeUnusedCSSOptions } from './unused-css.js';
 import { getPreset, getPresetNames } from '../presets.js';
 import { optionDefinitions, optionDefaults } from './option-definitions.js';
 
@@ -17,16 +18,18 @@ import { optionDefinitions, optionDefaults } from './option-definitions.js';
  * minification adds writable internal state on top of the public options
  * (set on prototype-chain forks during SVG/MathML namespace transitions)
  *
- * @typedef {Omit<MinifierOptions, 'preset' | 'canCollapseWhitespace' | 'canTrimWhitespace' | 'ignoreCustomComments' | 'log' | 'minifyCSS' | 'minifyJS' | 'minifyURLs' | 'minifySVG'> & {
+ * @typedef {Omit<MinifierOptions, 'preset' | 'canCollapseWhitespace' | 'canTrimWhitespace' | 'ignoreCustomComments' | 'log' | 'minifyCSS' | 'minifyJS' | 'minifyURLs' | 'minifySVG' | 'removeUnusedCSS'> & {
  *   name: (name: string) => string,
  *   log: (message: any) => unknown,
  *   ignoreCustomComments: RegExp[],
  *   canCollapseWhitespace: (tag: string, attrs: HTMLAttribute[], defaultFn: (tag: string) => boolean) => boolean,
  *   canTrimWhitespace: (tag: string, attrs: HTMLAttribute[], defaultFn: (tag: string) => boolean) => boolean,
- *   minifyCSS: (text: string, type?: string) => string | Promise<string>,
+ *   minifyCSS: (text: string, type?: string, usedSymbols?: Set<string>) => string | Promise<string>,
  *   minifyJS: (text: string, inline?: boolean, isModule?: boolean) => string | Promise<string>,
  *   minifyURLs: (text: string) => string | Promise<string>,
  *   minifySVG: ((svgContent: string) => string | Promise<string>) | null,
+ *   removeUnusedCSS: {safelist: Array<string | RegExp>, scripts: boolean} | null,
+ *   usedCSSSymbols?: Set<string>,
  *   nameParent?: (name: string) => string,
  *   nameHTML?: (name: string) => string,
  *   insideSVG?: boolean,
@@ -101,7 +104,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
     minifyCSS: identity,
     minifyJS: identity,
     minifyURLs: identity,
-    minifySVG: null
+    minifySVG: null,
+    removeUnusedCSS: null
   };
 
   const parseRegExpArray = (/** @type {unknown} */ arr) => {
@@ -170,6 +174,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       if (option) {
         options.name = identity;
       }
+    } else if (key === 'removeUnusedCSS') {
+      optionsDynamic.removeUnusedCSS = normalizeUnusedCSSOptions(option);
     } else if (key === 'log') {
       if (typeof option === 'function') {
         options.log = option;
@@ -184,7 +190,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       const cssLoader = getLightningCSS;
       const cssCache = cssMinifyCache;
 
-      options.minifyCSS = async function (/** @type {string} */ text, /** @type {string | undefined} */ type) {
+      options.minifyCSS = async function (/** @type {string} */ text, /** @type {string | undefined} */ type, /** @type {Set<string> | undefined} */ usedSymbols) {
         // Fast path: Nothing to minify
         if (!text || !text.trim()) {
           return text;
@@ -213,9 +219,22 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
           );
         }
 
-        // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys
+        // Unused-symbol removal applies to style sheets only
+        const unusedCSSConfig = type === undefined ? options.removeUnusedCSS : undefined;
+        const unusedSymbols = (unusedCSSConfig && usedSymbols)
+          ? findUnusedSymbols(text, usedSymbols, unusedCSSConfig.safelist)
+          : undefined;
+
+        // Cache key: Content + type + options signature; large inputs are hashed to avoid huge Map keys.
+        // The symbol list belongs in the signature: The cache outlives a single `minify()` call, so
+        // identical style sheets in differently marked-up documents must not share an entry.
         const inputCSS = wrapCSS(text, type);
-        const cssSig = stableStringify({ type, opts: lightningCssOptions, cont: !!options.continueOnMinifyError });
+        const cssSig = stableStringify({
+          type,
+          opts: lightningCssOptions,
+          cont: !!options.continueOnMinifyError,
+          unused: unusedSymbols && unusedSymbols.length ? unusedSymbols.slice().sort() : undefined
+        });
         const isCacheable = inputCSS.length <= MAX_CACHE_ENTRY_SIZE;
         const cssKey = isCacheable
           ? (inputCSS.length > 2048
@@ -242,8 +261,22 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
               code: Buffer.from(inputCSS),
               minify: true,
               errorRecovery: !!options.continueOnMinifyError,
-              ...lightningCssOptions
+              ...lightningCssOptions,
+              // Union, so that a manually supplied `unusedSymbols` list survives
+              ...(unusedSymbols && unusedSymbols.length
+                ? { unusedSymbols: lightningCssOptions.unusedSymbols ? [...new Set([...lightningCssOptions.unusedSymbols, ...unusedSymbols])] : unusedSymbols }
+                : {})
             });
+
+            // With `errorRecovery` enabled, Lightning CSS skips invalid rules instead of
+            // throwing, and reports each one here; surfacing them keeps a dropped rule
+            // from vanishing without a trace (fires on cache misses only)
+            if (options.log !== identity && result.warnings && result.warnings.length) {
+              for (const warning of result.warnings) {
+                const at = warning.loc ? ` (line ${warning.loc.line}, column ${warning.loc.column})` : '';
+                options.log(`Warning: Lightning CSS skipped invalid CSS${at}: ${warning.message}`);
+              }
+            }
 
             const outputCSS = unwrapCSS(result.code.toString(), type);
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -236,7 +236,8 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
         // second document with the same defect hears about it, too; `context.warned`
         // then keeps one document from repeating itself. Reporting from the cache
         // rather than only from the transform keeps the output independent of cache
-        // size and eviction.
+        // size and eviction. They are built and cached even when `log` is the default
+        // no-op, so a later document that does pass a `log` hook still gets them.
         const report = (/** @type {string[]} */ messages) => {
           if (!messages.length || options.log === identity) {
             return;

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -85,6 +85,7 @@ const presetNamesWarned = new Set();
 // The custom-fragment ReDoS warning is security-relevant, so it reaches the
 // console even without a `log` hook—once per process, like the warnings above
 let customFragmentQuantifierWarned = false;
+const unusedCSSWarned = new Set();
 
 // Main options processor
 
@@ -140,7 +141,7 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
   Object.keys(inputOptions).forEach(function (key) {
     if (!Object.hasOwn(optionDefinitions, key) && !optionKeysExtra.has(key) && !optionKeysWarned.has(key)) {
       optionKeysWarned.add(key);
-      warn(`HTML Minifier Next: Ignoring unknown or deprecated option “${key}” (see README for available options)`);
+      warn(`HTML Minifier Next: Ignoring unknown or deprecated option \`${key}\` (see README for available options)`);
     }
   });
 
@@ -548,6 +549,20 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
       optionsDynamic[key] = option;
     }
   });
+
+  // Unused-CSS removal rides along with Lightning CSS, so it silently does nothing
+  // when `minifyCSS` is off or replaced by a function—say so rather than let it pass
+  if (options.removeUnusedCSS) {
+    const cssOption = /** @type {Record<string, any>} */ (effectiveInput).minifyCSS;
+    const reason = typeof cssOption === 'function'
+      ? 'it does not apply when `minifyCSS` is a function'
+      : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
+    if (reason && !unusedCSSWarned.has(reason)) {
+      unusedCSSWarned.add(reason);
+      warn(`HTML Minifier Next: Ignoring \`removeUnusedCSS\`—${reason}`);
+    }
+  }
+
   return options;
 };
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -86,6 +86,8 @@ const presetNamesWarned = new Set();
 // console even without a `log` hook—once per process, like the warnings above
 let customFragmentQuantifierWarned = false;
 const unusedCSSWarned = new Set();
+// Invalid CSS reported by Lightning CSS, warned about once per distinct problem
+const cssWarned = new Set();
 
 // Main options processor
 
@@ -271,11 +273,17 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
 
             // With `errorRecovery` enabled, Lightning CSS skips invalid rules instead of
             // throwing, and reports each one here; surfacing them keeps a dropped rule
-            // from vanishing without a trace (fires on cache misses only)
+            // from vanishing without a trace. Deduplicating on the warning itself rather
+            // than leaving it to the cache keeps batch runs quiet without making the
+            // output depend on cache size or eviction.
             if (options.log !== identity && result.warnings && result.warnings.length) {
               for (const warning of result.warnings) {
                 const at = warning.loc ? ` (line ${warning.loc.line}, column ${warning.loc.column})` : '';
-                options.log(`Warning: Lightning CSS skipped invalid CSS${at}: ${warning.message}`);
+                const message = `Warning: Lightning CSS skipped invalid CSS${at}: ${warning.message}`;
+                if (!cssWarned.has(message)) {
+                  cssWarned.add(message);
+                  options.log(message);
+                }
               }
             }
 
@@ -557,9 +565,12 @@ const processOptions = (inputOptions, { getLightningCSS, getTerser, getSwc, getS
     const reason = typeof cssOption === 'function'
       ? 'it does not apply when `minifyCSS` is a function'
       : (options.minifyCSS === identity ? 'it requires `minifyCSS` (`--minify-css`)' : '');
-    if (reason && !unusedCSSWarned.has(reason)) {
-      unusedCSSWarned.add(reason);
-      warn(`HTML Minifier Next: Ignoring \`removeUnusedCSS\`—${reason}`);
+    if (reason) {
+      if (!unusedCSSWarned.has(reason)) {
+        unusedCSSWarned.add(reason);
+        warn(`HTML Minifier Next: Ignoring \`removeUnusedCSS\`—${reason}`);
+      }
+      options.removeUnusedCSS = null;
     }
   }
 

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -21,7 +21,7 @@ const idReferenceAttributes = new Set([
 ]);
 
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
-const identifierPattern = /-{0,2}[A-Za-z_][\w-]*/g;
+const identifierPattern = /--[\w-]*|-?[A-Za-z_][\w-]*/g;
 
 // CSS identifiers may contain escapes (`.md\:flex`, `.w-1\/2`), which have to be
 // resolved before comparing them against the plain tokens found in the markup

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -1,0 +1,167 @@
+// Unused-CSS removal for `style` elements, driven by the symbols a document actually references
+
+// Attributes whose values name elements by ID or hold space-separated ID lists
+const idReferenceAttributes = new Set([
+  'aria-activedescendant',
+  'aria-controls',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'aria-flowto',
+  'aria-labelledby',
+  'aria-owns',
+  'commandfor',
+  'contextmenu',
+  'for',
+  'form',
+  'headers',
+  'itemref',
+  'list',
+  'popovertarget'
+]);
+
+const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
+const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+const identifierPattern = /[A-Za-z_][\w-]*/g;
+
+// CSS identifiers may contain escapes (`.md\:flex`, `.w-1\/2`), which have to be
+// resolved before comparing them against the plain tokens found in the markup
+const cssIdentifierPattern = /(?<![\w\\-])[.#]((?:[-_a-zA-Z]|\\[0-9a-fA-F]{1,6}[ \t\n]?|\\[^\n0-9a-fA-F])(?:[-\w]|\\[0-9a-fA-F]{1,6}[ \t\n]?|\\[^\n0-9a-fA-F])*)/g;
+// `unusedSymbols` also drops `@keyframes` and `@counter-style` rules by name, so any
+// name used there is off limits even when no element carries it as a class or ID
+const reservedAtRulePattern = /@(?:-\w+-)?(?:keyframes|counter-style)\s+(-?[_a-zA-Z][\w-]*)/gi;
+const escapePattern = /\\(?:([0-9a-fA-F]{1,6})[ \t\n]?|(.))/g;
+
+/**
+ * Resolve CSS escape sequences in an identifier.
+ * @param {string} identifier
+ * @returns {string}
+ */
+function unescapeIdentifier(identifier) {
+  if (identifier.indexOf('\\') === -1) {
+    return identifier;
+  }
+  return identifier.replace(escapePattern, (_match, hex, literal) =>
+    hex ? String.fromCodePoint(parseInt(hex, 16)) : literal
+  );
+}
+
+/**
+ * Collect the class names and IDs a document references.
+ *
+ * `style` element contents are excluded, so that a style sheet never counts as
+ * evidence for its own selectors. Over-collecting is safe here (a symbol wrongly
+ * considered used is merely kept), under-collecting is not.
+ *
+ * @param {string} html - Raw document markup
+ * @param {boolean} includeScripts - Also treat identifiers inside inline `script` elements as used
+ * @returns {Set<string>} Symbols to keep
+ */
+function collectUsedSymbols(html, includeScripts) {
+  const used = new Set();
+  const markup = html.replace(styleElementPattern, '');
+
+  attributePattern.lastIndex = 0;
+  let match;
+  while ((match = attributePattern.exec(markup))) {
+    const name = (match[1] ?? '').toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    if (!value) {
+      continue;
+    }
+    if (name === 'class' || name === 'id' || idReferenceAttributes.has(name)) {
+      for (const token of value.split(/\s+/)) {
+        if (token) {
+          used.add(token);
+        }
+      }
+    } else if (name.startsWith('data-')) {
+      // Class names are commonly parked in `data-*` attributes for scripts to apply later
+      identifierPattern.lastIndex = 0;
+      let identifier;
+      while ((identifier = identifierPattern.exec(value))) {
+        used.add(identifier[0]);
+      }
+    }
+  }
+
+  if (includeScripts) {
+    scriptElementPattern.lastIndex = 0;
+    while ((match = scriptElementPattern.exec(markup))) {
+      const body = match[2];
+      if (!body) {
+        continue;
+      }
+      identifierPattern.lastIndex = 0;
+      let identifier;
+      while ((identifier = identifierPattern.exec(body))) {
+        used.add(identifier[0]);
+      }
+    }
+  }
+
+  return used;
+}
+
+/**
+ * Determine which class/ID symbols a style sheet defines but the document never references.
+ * @param {string} css - Style sheet contents
+ * @param {Set<string>} used - Symbols the document references
+ * @param {Array<string | RegExp>} safelist - Symbols to keep regardless
+ * @returns {string[]} Symbols safe to remove
+ */
+function findUnusedSymbols(css, used, safelist) {
+  const reserved = new Set();
+  reservedAtRulePattern.lastIndex = 0;
+  let match;
+  while ((match = reservedAtRulePattern.exec(css))) {
+    if (match[1]) {
+      reserved.add(match[1]);
+    }
+  }
+
+  const unused = [];
+  const seen = new Set();
+  cssIdentifierPattern.lastIndex = 0;
+  while ((match = cssIdentifierPattern.exec(css))) {
+    const symbol = unescapeIdentifier(match[1] ?? '');
+    if (seen.has(symbol)) {
+      continue;
+    }
+    seen.add(symbol);
+    if (used.has(symbol) || reserved.has(symbol)) {
+      continue;
+    }
+    if (safelist.some(entry => entry instanceof RegExp ? entry.test(symbol) : entry === symbol)) {
+      continue;
+    }
+    unused.push(symbol);
+  }
+
+  return unused;
+}
+
+/**
+ * Normalize the `removeUnusedCSS` option into a settled configuration.
+ * @param {boolean | {safelist?: Array<string | RegExp>, scripts?: boolean} | undefined} option
+ * @returns {{safelist: Array<string | RegExp>, scripts: boolean} | null} Null when disabled
+ */
+function normalizeUnusedCSSOptions(option) {
+  if (!option) {
+    return null;
+  }
+  const config = typeof option === 'object' ? option : {};
+  return {
+    safelist: Array.isArray(config.safelist) ? config.safelist : [],
+    // Keeping identifiers seen in inline scripts costs a little of the reduction
+    // but avoids the most common breakage, so it is the default
+    scripts: config.scripts !== false
+  };
+}
+
+export {
+  collectUsedSymbols,
+  findUnusedSymbols,
+  normalizeUnusedCSSOptions
+};

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -20,10 +20,6 @@ const idReferenceAttributes = new Set([
   'popovertarget'
 ]);
 
-// Browsers close a raw-text element on an end tag carrying whitespace, stray
-// attributes, or a slash (`</style >`, `</script\t\n bar>`, `</script/>`)
-const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi;
-const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script(?:[\s/][^>]*)?>/gi;
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
 const identifierPattern = /[A-Za-z_][\w-]*/g;
 
@@ -57,6 +53,78 @@ function unescapeIdentifier(identifier) {
 }
 
 /**
+ * Locate the bodies of a raw-text element (`style`, `script`).
+ *
+ * Scanning beats one regular expression here: A pattern permissive enough for the
+ * end tags browsers accept (`</script\t\n bar>`, `</script/>`) backtracks
+ * quadratically over a document full of near-matches, and bounding it would make
+ * long start tags go unrecognized.
+ *
+ * @param {string} html - Raw document markup
+ * @param {string} tagName - Lowercase element name
+ * @returns {Array<{start: number, bodyStart: number, bodyEnd: number, end: number, closed: boolean}>}
+ */
+function findRawTextElements(html, tagName) {
+  /** @type {Array<{start: number, bodyStart: number, bodyEnd: number, end: number, closed: boolean}>} */
+  const found = [];
+  const haystack = html.toLowerCase();
+  const openTag = '<' + tagName;
+  const closeTag = '</' + tagName;
+  // A tag name ends at whitespace, a slash, or the closing bracket—so `<styles>`
+  // and `</scriptfoo>` name different elements and must not match
+  const endsName = (/** @type {string} */ character) =>
+    character === '' || character === '/' || character === '>' || /\s/.test(character);
+
+  let cursor = 0;
+  for (;;) {
+    const start = haystack.indexOf(openTag, cursor);
+    if (start === -1) {
+      break;
+    }
+    if (!endsName(haystack.charAt(start + openTag.length))) {
+      cursor = start + openTag.length;
+      continue;
+    }
+    const startTagEnd = haystack.indexOf('>', start + openTag.length);
+    if (startTagEnd === -1) {
+      break;
+    }
+
+    const bodyStart = startTagEnd + 1;
+    let search = bodyStart;
+    let bodyEnd = -1;
+    let end = -1;
+    for (;;) {
+      const candidate = haystack.indexOf(closeTag, search);
+      if (candidate === -1) {
+        break;
+      }
+      if (endsName(haystack.charAt(candidate + closeTag.length))) {
+        const closeEnd = haystack.indexOf('>', candidate + closeTag.length);
+        if (closeEnd !== -1) {
+          bodyEnd = candidate;
+          end = closeEnd + 1;
+        }
+        break;
+      }
+      search = candidate + closeTag.length;
+    }
+
+    const closed = bodyEnd !== -1;
+    found.push({
+      start,
+      bodyStart,
+      bodyEnd: closed ? bodyEnd : html.length,
+      end: closed ? end : html.length,
+      closed
+    });
+    cursor = closed ? end : html.length;
+  }
+
+  return found;
+}
+
+/**
  * Collect the class names and IDs a document references.
  *
  * `style` element contents are excluded, so that a style sheet never counts as
@@ -65,20 +133,41 @@ function unescapeIdentifier(identifier) {
  *
  * @param {string} html - Raw document markup
  * @param {boolean} includeScripts - Also treat identifiers inside inline `script` elements as used
+ * @param {((text: string) => string)} [decode] - Resolves character references in attribute values
  * @returns {Set<string>} Symbols to keep
  */
-function collectUsedSymbols(html, includeScripts) {
+function collectUsedSymbols(html, includeScripts, decode) {
   const used = new Set();
-  const markup = html.replace(styleElementPattern, '');
+
+  // An unclosed `style` element is left in place: Its contents then read as markup,
+  // which can only add symbols, whereas dropping the rest of the document would lose them
+  let markup = html;
+  const styleElements = findRawTextElements(html, 'style');
+  for (let index = styleElements.length - 1; index >= 0; index--) {
+    const element = styleElements[index];
+    if (element?.closed) {
+      markup = markup.slice(0, element.start) + markup.slice(element.end);
+    }
+  }
+
+  const addIdentifiers = (/** @type {string} */ text) => {
+    identifierPattern.lastIndex = 0;
+    let identifier;
+    while ((identifier = identifierPattern.exec(text))) {
+      used.add(identifier[0]);
+    }
+  };
 
   attributePattern.lastIndex = 0;
   let match;
   while ((match = attributePattern.exec(markup))) {
     const name = (match[1] ?? '').toLowerCase();
-    const value = match[2] ?? match[3] ?? match[4] ?? '';
-    if (!value) {
+    const raw = match[2] ?? match[3] ?? match[4] ?? '';
+    if (!raw) {
       continue;
     }
+    // `class="us&#101;d"` names the class `used`, so compare against the decoded value
+    const value = (decode && raw.indexOf('&') !== -1) ? decode(raw) : raw;
     if (name === 'class' || name === 'id' || idReferenceAttributes.has(name)) {
       for (const token of value.split(/\s+/)) {
         if (token) {
@@ -87,26 +176,15 @@ function collectUsedSymbols(html, includeScripts) {
       }
     } else if (name.startsWith('data-')) {
       // Class names are commonly parked in `data-*` attributes for scripts to apply later
-      identifierPattern.lastIndex = 0;
-      let identifier;
-      while ((identifier = identifierPattern.exec(value))) {
-        used.add(identifier[0]);
-      }
+      addIdentifiers(value);
     }
   }
 
   if (includeScripts) {
-    scriptElementPattern.lastIndex = 0;
-    while ((match = scriptElementPattern.exec(markup))) {
-      const body = match[2];
-      if (!body) {
-        continue;
-      }
-      identifierPattern.lastIndex = 0;
-      let identifier;
-      while ((identifier = identifierPattern.exec(body))) {
-        used.add(identifier[0]);
-      }
+    // Script contents are raw text, so character references stay literal;
+    // an unclosed `script` runs to the end of the document, as it does in a browser
+    for (const element of findRawTextElements(markup, 'script')) {
+      addIdentifiers(markup.slice(element.bodyStart, element.bodyEnd));
     }
   }
 

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -20,8 +20,30 @@ const idReferenceAttributes = new Set([
   'popovertarget'
 ]);
 
+// Attributes whose value may be a same-document fragment URL (`#main`). `:target`
+// rules and SVG sprite references (`<use href="#icon">`) rest on these, so the ID
+// they name counts as used.
+const fragmentReferenceAttributes = new Set([
+  'action',
+  'cite',
+  'data',
+  'formaction',
+  'href',
+  'poster',
+  'src',
+  'usemap',
+  'xlink:href'
+]);
+
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
 const identifierPattern = /--[\w-]*|-?[A-Za-z_][\w-]*/g;
+// SVG paints and filters reach elements by ID through `url(#gradient)`, in
+// presentation attributes as well as in `style`
+const fragmentURLPattern = /url\(\s*['"]?#([^)'"\s]+)/gi;
+// Class names routinely carry characters that end a CSS identifier (`md:flex`,
+// `w-1/2`, `p-[3px]`), so scripts and `data-*` values contribute whole tokens
+// besides identifiers; quoted strings are where scripts keep such names
+const stringLiteralPattern = /'((?:[^'\\\n]|\\.)*)'|"((?:[^"\\\n]|\\.)*)"|`((?:[^`\\]|\\.)*)`/g;
 
 // CSS identifiers may contain escapes (`.md\:flex`, `.w-1\/2`), which have to be
 // resolved before comparing them against the plain tokens found in the markup
@@ -143,7 +165,7 @@ function findRawTextElements(haystack, tagName) {
 /**
  * Collect the class names and IDs a document references.
  *
- * `style` element contents are excluded, so that a style sheet never counts as
+ * Style sheet contents are excluded, so that a style sheet never counts as
  * evidence for its own selectors. Over-collecting is safe here (a symbol wrongly
  * considered used is merely kept), under-collecting is not.
  *
@@ -156,17 +178,29 @@ function collectUsedSymbols(html, includeScripts, decode) {
   const used = new Set();
   const haystack = foldCase(html);
 
-  // Style elements are skipped rather than cut out, so both scans share one folded
-  // copy and offsets keep pointing into `html`. An unclosed one is not skipped:
-  // Reading its contents as markup can only add symbols, whereas ignoring the rest
-  // of the document would lose them.
-  const skipped = findRawTextElements(haystack, 'style').filter(element => element.closed);
+  // Style sheets are skipped rather than cut out, so both scans share one folded
+  // copy and offsets keep pointing into `html`. Only the body is skipped—the start
+  // tag carries ordinary attributes, and `<style id="theme">` could be what
+  // `#theme` refers to. An unclosed element is not skipped: Reading its contents
+  // as markup can only add symbols, whereas ignoring the rest of the document
+  // would lose them.
+  const skipped = findRawTextElements(haystack, 'style')
+    .filter(element => element.closed)
+    .map(element => ({ start: element.bodyStart, end: element.bodyEnd }));
 
   const addIdentifiers = (/** @type {string} */ text) => {
     identifierPattern.lastIndex = 0;
     let identifier;
     while ((identifier = identifierPattern.exec(text))) {
       used.add(identifier[0]);
+    }
+  };
+
+  const addTokens = (/** @type {string} */ text) => {
+    for (const token of text.split(/\s+/)) {
+      if (token) {
+        used.add(token);
+      }
     }
   };
 
@@ -191,14 +225,21 @@ function collectUsedSymbols(html, includeScripts, decode) {
     // `class="us&#101;d"` names the class `used`, so compare against the decoded value
     const value = (decode && raw.indexOf('&') !== -1) ? decode(raw) : raw;
     if (name === 'class' || name === 'id' || idReferenceAttributes.has(name)) {
-      for (const token of value.split(/\s+/)) {
-        if (token) {
-          used.add(token);
-        }
-      }
+      addTokens(value);
     } else if (name.startsWith('data-')) {
       // Class names are commonly parked in `data-*` attributes for scripts to apply later
       addIdentifiers(value);
+      addTokens(value);
+    } else if (fragmentReferenceAttributes.has(name) && value.charAt(0) === '#') {
+      // Only a leading `#`: `href="/page#sec"` names a section of another document
+      addTokens(value.slice(1));
+    }
+    if (value.indexOf('(') !== -1) {
+      fragmentURLPattern.lastIndex = 0;
+      let reference;
+      while ((reference = fragmentURLPattern.exec(value))) {
+        addTokens(reference[1] ?? '');
+      }
     }
   }
 
@@ -207,8 +248,15 @@ function collectUsedSymbols(html, includeScripts, decode) {
     // an unclosed `script` runs to the end of the document, as it does in a browser
     skipCursor = 0;
     for (const element of findRawTextElements(haystack, 'script')) {
-      if (!isSkipped(element.start)) {
-        addIdentifiers(html.slice(element.bodyStart, element.bodyEnd));
+      if (isSkipped(element.start)) {
+        continue;
+      }
+      const body = html.slice(element.bodyStart, element.bodyEnd);
+      addIdentifiers(body);
+      stringLiteralPattern.lastIndex = 0;
+      let literal;
+      while ((literal = stringLiteralPattern.exec(body))) {
+        addTokens(literal[1] ?? literal[2] ?? literal[3] ?? '');
       }
     }
   }
@@ -262,21 +310,57 @@ function findUnusedSymbols(css, used, safelist) {
   return unused;
 }
 
+const unusedCSSKeys = new Set(['safelist', 'scripts']);
+
 /**
  * Normalize the `removeUnusedCSS` option into a settled configuration.
+ *
+ * A misspelled key or a safelist that is not an array would otherwise protect
+ * nothing, and that only surfaces as a missing rule much later—so every value
+ * that gets dropped is reported.
+ *
  * @param {boolean | {safelist?: Array<string | RegExp>, scripts?: boolean} | undefined} option
+ * @param {(message: string) => unknown} [warn] - Receives one message per ignored value
  * @returns {{safelist: Array<string | RegExp>, scripts: boolean} | null} Null when disabled
  */
-function normalizeUnusedCSSOptions(option) {
+function normalizeUnusedCSSOptions(option, warn) {
   if (!option) {
     return null;
   }
-  const config = typeof option === 'object' ? option : {};
+  const report = warn ?? (() => {});
+  const config = /** @type {Record<string, any>} */ (typeof option === 'object' ? option : {});
+
+  for (const key of Object.keys(config)) {
+    if (!unusedCSSKeys.has(key)) {
+      report(`Ignoring unknown \`removeUnusedCSS\` key \`${key}\`—expected \`safelist\` or \`scripts\``);
+    }
+  }
+
+  /** @type {Array<string | RegExp>} */
+  let safelist = [];
+  if (config.safelist !== undefined) {
+    if (!Array.isArray(config.safelist)) {
+      report('Ignoring `removeUnusedCSS.safelist`—it takes an array of strings and regular expressions');
+    } else {
+      safelist = config.safelist.filter((/** @type {unknown} */ entry) => {
+        if (typeof entry === 'string' || entry instanceof RegExp) {
+          return true;
+        }
+        report(`Ignoring \`removeUnusedCSS.safelist\` entry of type ${typeof entry}—entries must be strings or regular expressions`);
+        return false;
+      });
+    }
+  }
+
+  if (config.scripts !== undefined && typeof config.scripts !== 'boolean') {
+    report('Ignoring `removeUnusedCSS.scripts`—it takes a boolean');
+  }
+
   return {
-    safelist: Array.isArray(config.safelist) ? config.safelist : [],
+    safelist,
     // Keeping identifiers seen in inline scripts costs a little of the reduction
     // but avoids the most common breakage, so it is the default
-    scripts: config.scripts !== false
+    scripts: typeof config.scripts === 'boolean' ? config.scripts : true
   };
 }
 

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -20,8 +20,10 @@ const idReferenceAttributes = new Set([
   'popovertarget'
 ]);
 
-const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style\s*>/gi;
-const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+// Browsers close a raw-text element on an end tag carrying whitespace, stray
+// attributes, or a slash (`</style >`, `</script\t\n bar>`, `</script/>`)
+const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi;
+const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script(?:[\s/][^>]*)?>/gi;
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
 const identifierPattern = /[A-Za-z_][\w-]*/g;
 

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -1,4 +1,4 @@
-// Unused-CSS removal for `style` elements, driven by the symbols a document actually references
+// Unused-CSS removal
 
 // Attributes whose values name elements by ID or hold space-separated ID lists
 const idReferenceAttributes = new Set([

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -21,7 +21,7 @@ const idReferenceAttributes = new Set([
 ]);
 
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
-const identifierPattern = /[A-Za-z_][\w-]*/g;
+const identifierPattern = /-{0,2}[A-Za-z_][\w-]*/g;
 
 // CSS identifiers may contain escapes (`.md\:flex`, `.w-1\/2`), which have to be
 // resolved before comparing them against the plain tokens found in the markup

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -20,8 +20,8 @@ const idReferenceAttributes = new Set([
   'popovertarget'
 ]);
 
-const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
-const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const styleElementPattern = /<style\b[^>]*>[\s\S]*?<\/style\s*>/gi;
+const scriptElementPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
 const identifierPattern = /[A-Za-z_][\w-]*/g;
 
@@ -42,9 +42,16 @@ function unescapeIdentifier(identifier) {
   if (identifier.indexOf('\\') === -1) {
     return identifier;
   }
-  return identifier.replace(escapePattern, (_match, hex, literal) =>
-    hex ? String.fromCodePoint(parseInt(hex, 16)) : literal
-  );
+  return identifier.replace(escapePattern, (_match, hex, literal) => {
+    if (!hex) {
+      return literal;
+    }
+    // Per CSS Syntax spec, a null, surrogate, or out-of-range escape becomes U+FFFD
+    const code = parseInt(hex, 16);
+    return (code === 0 || code > 0x10FFFF || (code >= 0xD800 && code <= 0xDFFF))
+      ? '\uFFFD'
+      : String.fromCodePoint(code);
+  });
 }
 
 /**
@@ -133,7 +140,15 @@ function findUnusedSymbols(css, used, safelist) {
     if (used.has(symbol) || reserved.has(symbol)) {
       continue;
     }
-    if (safelist.some(entry => entry instanceof RegExp ? entry.test(symbol) : entry === symbol)) {
+    if (safelist.some(entry => {
+      if (!(entry instanceof RegExp)) {
+        return entry === symbol;
+      }
+      // `test()` advances `lastIndex` on global and sticky patterns, which would
+      // make a safelist entry match only every other symbol
+      entry.lastIndex = 0;
+      return entry.test(symbol);
+    })) {
       continue;
     }
     unused.push(symbol);

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -1,5 +1,7 @@
 // Unused-CSS removal
 
+import { findTagEnd } from './utils.js';
+
 // Attributes whose values name elements by ID or hold space-separated ID lists
 const idReferenceAttributes = new Set([
   'aria-activedescendant',
@@ -34,6 +36,9 @@ const fragmentReferenceAttributes = new Set([
   'usemap',
   'xlink:href'
 ]);
+
+// `srcdoc` can nest, and each level costs another scan of its own markup
+const SRCDOC_MAX_DEPTH = 3;
 
 const attributePattern = /(?:^|[\s/])([-\w:.]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
 const identifierPattern = /--[\w-]*|-?[A-Za-z_][\w-]*/g;
@@ -123,7 +128,9 @@ function findRawTextElements(haystack, tagName) {
       cursor = start + openTag.length;
       continue;
     }
-    const startTagEnd = haystack.indexOf('>', start + openTag.length);
+    // A quoted attribute value may hold a `>`, so the tag ends where the parser
+    // says it does, not at the next bracket
+    const startTagEnd = findTagEnd(haystack, start + openTag.length);
     if (startTagEnd === -1) {
       break;
     }
@@ -138,7 +145,7 @@ function findRawTextElements(haystack, tagName) {
         break;
       }
       if (endsName(haystack.charAt(candidate + closeTag.length))) {
-        const closeEnd = haystack.indexOf('>', candidate + closeTag.length);
+        const closeEnd = findTagEnd(haystack, candidate + closeTag.length);
         if (closeEnd !== -1) {
           bodyEnd = candidate;
           end = closeEnd + 1;
@@ -172,9 +179,10 @@ function findRawTextElements(haystack, tagName) {
  * @param {string} html - Raw document markup
  * @param {boolean} includeScripts - Also treat identifiers inside inline `script` elements as used
  * @param {((text: string) => string)} [decode] - Resolves character references in attribute values
+ * @param {number} [depth] - Nesting level, counted through `srcdoc`
  * @returns {Set<string>} Symbols to keep
  */
-function collectUsedSymbols(html, includeScripts, decode) {
+function collectUsedSymbols(html, includeScripts, decode, depth = 0) {
   const used = new Set();
   const haystack = foldCase(html);
 
@@ -214,6 +222,9 @@ function collectUsedSymbols(html, includeScripts, decode) {
     return element !== undefined && index >= element.start;
   };
 
+  /** @type {string[]} */
+  const nested = [];
+
   attributePattern.lastIndex = 0;
   let match;
   while ((match = attributePattern.exec(html))) {
@@ -233,6 +244,8 @@ function collectUsedSymbols(html, includeScripts, decode) {
     } else if (fragmentReferenceAttributes.has(name) && value.charAt(0) === '#') {
       // Only a leading `#`: `href="/page#sec"` names a section of another document
       addTokens(value.slice(1));
+    } else if (name === 'srcdoc' && depth < SRCDOC_MAX_DEPTH) {
+      nested.push(value);
     }
     if (value.indexOf('(') !== -1) {
       fragmentURLPattern.lastIndex = 0;
@@ -240,6 +253,16 @@ function collectUsedSymbols(html, includeScripts, decode) {
       while ((reference = fragmentURLPattern.exec(value))) {
         addTokens(reference[1] ?? '');
       }
+    }
+  }
+
+  // `iframe srcdoc` holds a document of its own, whose style sheets are minified
+  // against this very set—so what it references has to be in it. The scan runs here
+  // rather than at the attribute: The patterns it shares with this one are
+  // module-level, so no nested scan may start while one of their loops is open.
+  for (const markup of nested) {
+    for (const symbol of collectUsedSymbols(markup, includeScripts, decode, depth + 1)) {
+      used.add(symbol);
     }
   }
 

--- a/src/lib/unused-css.js
+++ b/src/lib/unused-css.js
@@ -53,6 +53,23 @@ function unescapeIdentifier(identifier) {
 }
 
 /**
+ * Lowercase for matching without disturbing offsets.
+ *
+ * `toLowerCase()` can change a string's length—U+0130 becomes two code units—which
+ * would misalign every offset taken from the result. Folding just ASCII preserves
+ * length, and tag names are ASCII anyway.
+ *
+ * @param {string} text
+ * @returns {string} Same length as `text`
+ */
+function foldCase(text) {
+  const lowercased = text.toLowerCase();
+  return lowercased.length === text.length
+    ? lowercased
+    : text.replace(/[A-Z]+/g, uppercase => uppercase.toLowerCase());
+}
+
+/**
  * Locate the bodies of a raw-text element (`style`, `script`).
  *
  * Scanning beats one regular expression here: A pattern permissive enough for the
@@ -60,14 +77,13 @@ function unescapeIdentifier(identifier) {
  * quadratically over a document full of near-matches, and bounding it would make
  * long start tags go unrecognized.
  *
- * @param {string} html - Raw document markup
+ * @param {string} haystack - Case-folded markup, as returned by `foldCase`
  * @param {string} tagName - Lowercase element name
  * @returns {Array<{start: number, bodyStart: number, bodyEnd: number, end: number, closed: boolean}>}
  */
-function findRawTextElements(html, tagName) {
+function findRawTextElements(haystack, tagName) {
   /** @type {Array<{start: number, bodyStart: number, bodyEnd: number, end: number, closed: boolean}>} */
   const found = [];
-  const haystack = html.toLowerCase();
   const openTag = '<' + tagName;
   const closeTag = '</' + tagName;
   // A tag name ends at whitespace, a slash, or the closing bracket—so `<styles>`
@@ -114,11 +130,11 @@ function findRawTextElements(html, tagName) {
     found.push({
       start,
       bodyStart,
-      bodyEnd: closed ? bodyEnd : html.length,
-      end: closed ? end : html.length,
+      bodyEnd: closed ? bodyEnd : haystack.length,
+      end: closed ? end : haystack.length,
       closed
     });
-    cursor = closed ? end : html.length;
+    cursor = closed ? end : haystack.length;
   }
 
   return found;
@@ -138,17 +154,13 @@ function findRawTextElements(html, tagName) {
  */
 function collectUsedSymbols(html, includeScripts, decode) {
   const used = new Set();
+  const haystack = foldCase(html);
 
-  // An unclosed `style` element is left in place: Its contents then read as markup,
-  // which can only add symbols, whereas dropping the rest of the document would lose them
-  let markup = html;
-  const styleElements = findRawTextElements(html, 'style');
-  for (let index = styleElements.length - 1; index >= 0; index--) {
-    const element = styleElements[index];
-    if (element?.closed) {
-      markup = markup.slice(0, element.start) + markup.slice(element.end);
-    }
-  }
+  // Style elements are skipped rather than cut out, so both scans share one folded
+  // copy and offsets keep pointing into `html`. An unclosed one is not skipped:
+  // Reading its contents as markup can only add symbols, whereas ignoring the rest
+  // of the document would lose them.
+  const skipped = findRawTextElements(haystack, 'style').filter(element => element.closed);
 
   const addIdentifiers = (/** @type {string} */ text) => {
     identifierPattern.lastIndex = 0;
@@ -158,14 +170,24 @@ function collectUsedSymbols(html, includeScripts, decode) {
     }
   };
 
+  // Both loops below walk forward, so one cursor over the skipped ranges suffices
+  let skipCursor = 0;
+  const isSkipped = (/** @type {number} */ index) => {
+    while (skipCursor < skipped.length && (skipped[skipCursor]?.end ?? 0) <= index) {
+      skipCursor++;
+    }
+    const element = skipped[skipCursor];
+    return element !== undefined && index >= element.start;
+  };
+
   attributePattern.lastIndex = 0;
   let match;
-  while ((match = attributePattern.exec(markup))) {
-    const name = (match[1] ?? '').toLowerCase();
+  while ((match = attributePattern.exec(html))) {
     const raw = match[2] ?? match[3] ?? match[4] ?? '';
-    if (!raw) {
+    if (!raw || isSkipped(match.index)) {
       continue;
     }
+    const name = (match[1] ?? '').toLowerCase();
     // `class="us&#101;d"` names the class `used`, so compare against the decoded value
     const value = (decode && raw.indexOf('&') !== -1) ? decode(raw) : raw;
     if (name === 'class' || name === 'id' || idReferenceAttributes.has(name)) {
@@ -183,8 +205,11 @@ function collectUsedSymbols(html, includeScripts, decode) {
   if (includeScripts) {
     // Script contents are raw text, so character references stay literal;
     // an unclosed `script` runs to the end of the document, as it does in a browser
-    for (const element of findRawTextElements(markup, 'script')) {
-      addIdentifiers(markup.slice(element.bodyStart, element.bodyEnd));
+    skipCursor = 0;
+    for (const element of findRawTextElements(haystack, 'script')) {
+      if (!isSkipped(element.start)) {
+        addIdentifiers(html.slice(element.bodyStart, element.bodyEnd));
+      }
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -146,8 +146,31 @@ function parseRegExp(value) {
 
 // Exports
 
+/**
+ * Find the index of the `>` that closes an opening tag, correctly skipping
+ * over quoted attribute values (which may contain `>`).
+ * @param {string} html
+ * @param {number} pos - Start position (just after the tag name)
+ * @returns {number} Index of the closing `>`, or -1 if not found
+ */
+function findTagEnd(html, pos) {
+  let i = pos;
+  while (i < html.length) {
+    const ch = html[i];
+    if (ch === '>') return i;
+    if (ch === '"' || ch === "'") {
+      const q = ch;
+      i++;
+      while (i < html.length && html[i] !== q) i++;
+    }
+    i++;
+  }
+  return -1;
+}
+
 export {
   stableStringify,
+  findTagEnd,
   LRU,
   MAX_CACHE_ENTRY_SIZE,
   hashContent,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1007,6 +1007,65 @@ describe('CLI', () => {
     assert.strictEqual(existsFixture('tmp/verbose-stdin.html'), true);
   });
 
+  test('Should report skipped CSS rules in verbose mode', () => {
+    const result = execCliWithStderr([
+      'invalid-css-js.html',
+      '--verbose',
+      '--minify-css',
+      '-o', 'tmp/invalid-css.html'
+    ]);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(
+      result.stderr.includes('Lightning CSS skipped invalid CSS'),
+      'Rules dropped under error recovery should be reported'
+    );
+  });
+
+  test('Should report swallowed minification errors in verbose mode', () => {
+    const result = execCliWithStderr([
+      'invalid-css-js.html',
+      '--verbose',
+      '--minify-js',
+      '-o', 'tmp/invalid-js.html'
+    ]);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(
+      result.stderr.includes('Minification failed, content left as-is'),
+      'Errors swallowed by `continueOnMinifyError` should be reported'
+    );
+  });
+
+  test('Should stay quiet about minifier diagnostics without verbose mode', () => {
+    const result = execCliWithStderr([
+      'invalid-css-js.html',
+      '--minify-css',
+      '--minify-js',
+      '-o', 'tmp/invalid-quiet.html'
+    ]);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(!result.stderr.includes('Lightning CSS skipped invalid CSS'));
+    assert.ok(!result.stderr.includes('Minification failed, content left as-is'));
+    assert.strictEqual(existsFixture('tmp/invalid-quiet.html'), true);
+  });
+
+  test('Should report minifier diagnostics with `--dry` flag', () => {
+    const result = execCliWithStderr([
+      'invalid-css-js.html',
+      '--dry',
+      '--minify-css'
+    ]);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('[DRY RUN]'));
+    assert.ok(
+      result.stderr.includes('Lightning CSS skipped invalid CSS'),
+      '`--dry` implies verbose, so diagnostics should show there too'
+    );
+  });
+
   test('Should automatically enable verbose mode with `--dry` flag', () => {
     const result = execCliWithStderr([
       'default.html',

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -635,15 +635,25 @@ describe('CLI', () => {
   });
 
   test('Should still read `"true"` and `"false"` in a config file as booleans', () => {
-    const dir = setupConfigDir('config-boolean-string', {
+    const input = '<style>.a { color : red }</style>';
+
+    const dirOn = setupConfigDir('config-boolean-string-on', {
       'html-minifier-next.config.json': { minifyCSS: 'true' }
     });
-    fs.writeFileSync(path.join(dir, 'input.html'), '<style>.a { color : red }</style>');
+    fs.writeFileSync(path.join(dirOn, 'input.html'), input);
+    const on = execCliInDir(['input.html'], dirOn);
 
-    const { stdout, exitCode } = execCliInDir(['input.html'], dir);
+    assert.strictEqual(on.exitCode, 0);
+    assert.strictEqual(on.stdout, '<style>.a{color:red}</style>', '`"true"` should enable minification');
 
-    assert.strictEqual(exitCode, 0);
-    assert.strictEqual(stdout, '<style>.a{color:red}</style>', 'JSON-parsed config values keep working');
+    const dirOff = setupConfigDir('config-boolean-string-off', {
+      'html-minifier-next.config.json': { minifyCSS: 'false' }
+    });
+    fs.writeFileSync(path.join(dirOff, 'input.html'), input);
+    const off = execCliInDir(['input.html'], dirOff);
+
+    assert.strictEqual(off.exitCode, 0);
+    assert.strictEqual(off.stdout, input, '`"false"` should leave the CSS alone');
   });
 
   test('Should prefer html-minifier-next.config.json over htmlminifier.config.json', () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -603,7 +603,7 @@ describe('CLI', () => {
     const { stdout, stderr, exitCode } = execCliInDir(['input.html'], dir);
 
     assert.strictEqual(exitCode, 0);
-    assert.ok(stderr.includes('Using config file “html-minifier-next.config.json”'));
+    assert.ok(stderr.includes('Using config file html-minifier-next.config.json'));
     assert.strictEqual(stdout, '<p>foo</p>');
   });
 
@@ -615,7 +615,7 @@ describe('CLI', () => {
     const { stdout, stderr, exitCode } = execCliInDir(['input.html'], dir);
 
     assert.strictEqual(exitCode, 0);
-    assert.ok(stderr.includes('Using config file “htmlminifier.config.json”'));
+    assert.ok(stderr.includes('Using config file htmlminifier.config.json'));
     assert.strictEqual(stdout, '<p>foo</p>');
   });
 
@@ -628,7 +628,7 @@ describe('CLI', () => {
     const { stdout, stderr, exitCode } = execCliInDir(['input.html'], dir);
 
     assert.strictEqual(exitCode, 0);
-    assert.ok(stderr.includes('Using config file “html-minifier-next.config.json”'));
+    assert.ok(stderr.includes('Using config file html-minifier-next.config.json'));
     assert.strictEqual(stdout, '<p>foo</p>');
   });
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -619,6 +619,33 @@ describe('CLI', () => {
     assert.strictEqual(stdout, '<p>foo</p>');
   });
 
+  test('Should refuse a string value for an object-valued option in a config file', () => {
+    // Config values are JSON-parsed first, so `"true"` and `"false"` arrive as
+    // booleans; anything that is not JSON stays a string and used to read as “on”
+    const dir = setupConfigDir('config-string-value', {
+      'html-minifier-next.config.json': { minifyCSS: 'yes' }
+    });
+    fs.writeFileSync(path.join(dir, 'input.html'), '<style>.a { color : red }</style>');
+
+    const { stdout, stderr, exitCode } = execCliInDir(['input.html'], dir);
+
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(stdout, '<style>.a { color : red }</style>', 'A string must not enable minification');
+    assert.ok(stderr.includes('minifyCSS'), 'The rejected value should be reported');
+  });
+
+  test('Should still read `"true"` and `"false"` in a config file as booleans', () => {
+    const dir = setupConfigDir('config-boolean-string', {
+      'html-minifier-next.config.json': { minifyCSS: 'true' }
+    });
+    fs.writeFileSync(path.join(dir, 'input.html'), '<style>.a { color : red }</style>');
+
+    const { stdout, exitCode } = execCliInDir(['input.html'], dir);
+
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(stdout, '<style>.a{color:red}</style>', 'JSON-parsed config values keep working');
+  });
+
   test('Should prefer html-minifier-next.config.json over htmlminifier.config.json', () => {
     const dir = setupConfigDir('config-default-precedence', {
       'html-minifier-next.config.json': { removeComments: true },
@@ -1007,7 +1034,7 @@ describe('CLI', () => {
     assert.strictEqual(existsFixture('tmp/verbose-stdin.html'), true);
   });
 
-  test('Should report skipped CSS rules in verbose mode', () => {
+  test('Should report invalid CSS in verbose mode', () => {
     const result = execCliWithStderr([
       'invalid-css-js.html',
       '--verbose',
@@ -1017,8 +1044,8 @@ describe('CLI', () => {
 
     assert.strictEqual(result.exitCode, 0);
     assert.ok(
-      result.stderr.includes('Lightning CSS skipped invalid CSS'),
-      'Rules dropped under error recovery should be reported'
+      result.stderr.includes('Lightning CSS reported invalid CSS'),
+      'Rules flagged under error recovery should be reported'
     );
   });
 
@@ -1046,7 +1073,7 @@ describe('CLI', () => {
     ]);
 
     assert.strictEqual(result.exitCode, 0);
-    assert.ok(!result.stderr.includes('Lightning CSS skipped invalid CSS'));
+    assert.ok(!result.stderr.includes('Lightning CSS reported invalid CSS'));
     assert.ok(!result.stderr.includes('Minification failed, content left as-is'));
     assert.strictEqual(existsFixture('tmp/invalid-quiet.html'), true);
   });
@@ -1061,9 +1088,52 @@ describe('CLI', () => {
     assert.strictEqual(result.exitCode, 0);
     assert.ok(result.stderr.includes('[DRY RUN]'));
     assert.ok(
-      result.stderr.includes('Lightning CSS skipped invalid CSS'),
+      result.stderr.includes('Lightning CSS reported invalid CSS'),
       '`--dry` implies verbose, so diagnostics should show there too'
     );
+  });
+
+  test('Should remove unused CSS with `--remove-unused-css`', () => {
+    const output = execCli(['unused-css.html', '--minify-css', '--remove-unused-css']);
+
+    assert.ok(output.includes('.used'), 'Referenced class should be kept');
+    assert.ok(!output.includes('.unused'), 'Unreferenced class should be removed');
+  });
+
+  test('Should accept a `--remove-unused-css` safelist as JSON', () => {
+    const output = execCli(['unused-css.html', '--minify-css', '--remove-unused-css={"safelist":["safe-a"]}']);
+
+    assert.ok(output.includes('.safe-a'), 'Safelisted class should be kept');
+    assert.ok(!output.includes('.unused'), 'Unsafelisted class should still be removed');
+  });
+
+  test('Should refuse `--remove-unused-css` without `--minify-css`', () => {
+    const result = execCliWithStderr(['unused-css.html', '--remove-unused-css']);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(result.stdout.includes('.unused'), 'Nothing should be removed without `--minify-css`');
+    assert.ok(
+      result.stderr.includes('removeUnusedCSS') && result.stderr.includes('--minify-css'),
+      'The warning should name the flag a CLI user would reach for'
+    );
+  });
+
+  test('Should refuse a non-JSON `--minify-css` value', () => {
+    // A bare word parses as a string, which carries no configuration
+    const result = execCliWithStderr(['unused-css.html', '--minify-css=yes']);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(result.stdout.includes('<title>Unused CSS</title>'), 'The document should still be written');
+    assert.ok(result.stderr.includes('minifyCSS'), 'The rejected value should be reported');
+  });
+
+  test('Should refuse a non-JSON `--remove-unused-css` value', () => {
+    // A bare word parses as a string, which must not read as “on”
+    const result = execCliWithStderr(['unused-css.html', '--minify-css', '--remove-unused-css=yes']);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(result.stdout.includes('.unused'), 'A string must not enable the option');
+    assert.ok(result.stderr.includes('removeUnusedCSS'), 'The rejected value should be reported');
   });
 
   test('Should automatically enable verbose mode with `--dry` flag', () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -987,15 +987,39 @@ describe('CSS and JS', () => {
       assert.ok(!styleOf(unrelated).includes('.gone'), 'Unreferenced rules should still be removed');
     });
 
+    test('Keeps offsets aligned when lowercasing changes length', async () => {
+      // U+0130 lowercases to two code units, which would shift every later offset—and
+      // a shifted strip leaves `class` glued to the preceding text, so it stops parsing
+      const input = '<p title="\u0130\u0130\u0130">x</p>' +
+        '<style>.used{color:red}.gone{color:red}</style><p class="used"></p>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.used'), 'Referenced rule must survive a length-changing character');
+      assert.ok(!styleOf(output).includes('.gone'), 'Unreferenced rule should still be removed');
+    });
+
     test('Scans raw-text elements in linear time', () => {
       // A regular expression permissive enough for malformed end tags backtracked
-      // quadratically here—30,000 near-matches took seconds rather than milliseconds
-      const input = '<style>' + '</style\t'.repeat(15000) + '<script>' + '<script\t'.repeat(15000);
+      // quadratically over near-matches; compare growth rather than absolute time,
+      // which would depend on the machine. No `>` may follow the repetitions—one
+      // lets the pattern succeed immediately, which is what makes the near-matches
+      // pathological rather than merely long.
+      const measure = (/** @type {number} */ count) => {
+        const input = '<style>' + '</style\t'.repeat(count);
+        const started = performance.now();
+        collectUsedSymbols(input, true);
+        return performance.now() - started;
+      };
 
-      const started = Date.now();
-      collectUsedSymbols(input, true);
+      const small = measure(8000);
+      const large = measure(16000);
 
-      assert.ok(Date.now() - started < 2000, 'Near-matches should not degrade into quadratic scanning');
+      // Doubling the input doubles a linear scan but quadruples a quadratic one; the
+      // constant absorbs timer noise, which dominates when both runs are near-instant
+      assert.ok(
+        large <= small * 3 + 50,
+        `Scanning grew from ${small.toFixed(1)} ms to ${large.toFixed(1)} ms on twice the input`
+      );
     });
 
     test('Stops stripping a stylesheet at its own end tag, however malformed', async () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -834,11 +834,37 @@ describe('CSS and JS', () => {
       assert.ok(!styleOf(output).includes('#gone'), 'Unreferenced ID should be removed');
     });
 
-    test('Requires `minifyCSS`', async () => {
+    test('Requires `minifyCSS`, and says so', async () => {
       const input = style('.unused{color:red}') + '<p></p>';
-      const output = await minify(input, { removeUnusedCSS: true });
+      const logs = [];
+      const output = await minify(input, { removeUnusedCSS: true, log: message => logs.push(String(message)) });
 
       assert.ok(styleOf(output).includes('.unused'), 'Without `minifyCSS` nothing should be removed');
+      assert.ok(
+        logs.some(message => message.includes('removeUnusedCSS') && message.includes('requires')),
+        'Silently doing nothing would be the surprise, so it should warn'
+      );
+      assert.ok(
+        logs.some(message => message.includes('--minify-css')),
+        'The warning should name the flag a CLI user would reach for'
+      );
+    });
+
+    test('Reports that a `minifyCSS` function takes over', async () => {
+      // The removal rides along with Lightning CSS, which a custom function replaces
+      const input = style('.unused{color:red}') + '<p></p>';
+      const logs = [];
+      const output = await minify(input, {
+        minifyCSS: text => text,
+        removeUnusedCSS: true,
+        log: message => logs.push(String(message))
+      });
+
+      assert.ok(styleOf(output).includes('.unused'), 'A `minifyCSS` function minifies CSS itself');
+      assert.ok(
+        logs.some(message => message.includes('removeUnusedCSS') && message.includes('function')),
+        'The combination should warn rather than pass silently'
+      );
     });
 
     test('Keeps symbols referenced from ID references and `data-*` attributes', async () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -887,6 +887,28 @@ describe('CSS and JS', () => {
       assert.ok(!styleOf(unguarded).includes('.js-only'), '`scripts: false` should drop the guard');
     });
 
+    test('Keeps hyphen-leading class names found in scripts and `data-*` values', async () => {
+      // `.-mt-4` and the like are ordinary CSS identifiers a script hands to `classList`
+      const cases = [
+        ['.-foo{color:red}', '<script>document.body.classList.add("-foo")</script>', '.-foo'],
+        ['.-mt-4{margin-top:-1rem}', '<script>el.classList.add("-mt-4")</script>', '.-mt-4'],
+        ['.--foo{color:red}', '<script>el.classList.add("--foo")</script>', '.--foo'],
+        ['.-foo{color:red}', '<p data-toggle="-foo"></p>', '.-foo']
+      ];
+
+      for (const [css, markup, expected] of cases) {
+        const output = await minify(style(css) + '<p></p>' + markup, { minifyCSS: true, removeUnusedCSS: true });
+        assert.ok(styleOf(output).includes(expected), `${markup} should keep ${expected}`);
+      }
+
+      // A hyphen-leading name nothing references should still go
+      const unused = await minify(style('.-gone{color:red}') + '<p></p>', {
+        minifyCSS: true,
+        removeUnusedCSS: true
+      });
+      assert.ok(!styleOf(unused).includes('.-gone'), 'Unreferenced rules should still be removed');
+    });
+
     test('Honors the safelist, as strings and as regular expressions', async () => {
       const input = style('.keep-me{color:red}.keep-prefix-a{color:red}.drop{color:red}') + '<p></p>';
       const output = await minify(input, {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -936,6 +936,37 @@ describe('CSS and JS', () => {
       assert.ok(styleOf(output).includes('.js-x'), '`</script >` should still be recognized as an end tag');
     });
 
+    test('Reads raw-text elements whose end tag carries attributes or a slash', async () => {
+      // Browsers close the element on all of these, so the script body still runs
+      const endTags = ['</script\t\n bar>', '</script foo="bar">', '</script/>', '</script >trailing'];
+
+      for (const endTag of endTags) {
+        const input = style('.js-x{color:red}') +
+          `<p></p><script>document.body.classList.add("js-x")${endTag}`;
+        const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+        assert.ok(styleOf(output).includes('.js-x'), `“${endTag}” should be recognized as an end tag`);
+      }
+    });
+
+    test('Does not mistake a longer tag name for a raw-text end tag', async () => {
+      const input = style('.js-x{color:red}') +
+        '<p></p><script>document.body.classList.add("js-x")</scriptfoo>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      // `</scriptfoo>` closes nothing, so the script body is never scanned
+      assert.ok(!styleOf(output).includes('.js-x'), '`</scriptfoo>` must not count as an end tag');
+    });
+
+    test('Stops stripping a stylesheet at its own end tag, however malformed', async () => {
+      // A missed end tag would let the body run on to the next one, swallowing markup
+      const input = '<style>.a{color:red}</style bar><p class="a b"></p><style>.b{color:red}</style>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(output.includes('.a{color:red}'), 'Class before the second stylesheet should be kept');
+      assert.ok(output.includes('.b{color:red}'), 'Class after the first stylesheet should be kept');
+    });
+
     test('Honors a safelist entry that is a global regular expression', async () => {
       const input = style('.js-a{color:red}.js-b{color:red}.js-c{color:red}') + '<p></p>';
       const output = await minify(input, {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -1,6 +1,7 @@
 import {describe, test} from 'node:test';
 import assert from 'node:assert';
 import { minify, getCacheStats } from '../src/htmlminifier.js';
+import { collectUsedSymbols } from '../src/lib/unused-css.js';
 
 describe('CSS and JS', () => {
   test('CSS minification', async () => {
@@ -949,13 +950,52 @@ describe('CSS and JS', () => {
       }
     });
 
-    test('Does not mistake a longer tag name for a raw-text end tag', async () => {
+    test('Does not mistake a longer tag name for a raw-text tag', async () => {
+      // `</scriptfoo>` closes nothing, so what follows is still script content
       const input = style('.js-x{color:red}') +
-        '<p></p><script>document.body.classList.add("js-x")</scriptfoo>';
+        '<p></p><script>void 0</scriptfoo>document.body.classList.add("js-x")';
       const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
 
-      // `</scriptfoo>` closes nothing, so the script body is never scanned
-      assert.ok(!styleOf(output).includes('.js-x'), '`</scriptfoo>` must not count as an end tag');
+      assert.ok(styleOf(output).includes('.js-x'), 'Script content should run past a non-matching end tag');
+
+      // Likewise, `<styles>` is a different element and must not be stripped as a style sheet
+      const other = '<styles class="kept"></styles>' + style('.kept{color:red}') + '<p></p>';
+      assert.ok(
+        styleOf(await minify(other, { minifyCSS: true, removeUnusedCSS: true })).includes('.kept'),
+        '`<styles>` must not be treated as a `style` element'
+      );
+    });
+
+    test('Decodes character references in attribute values', async () => {
+      const cases = [
+        ['.used{color:red}', '<p class="us&#101;d"></p>', '.used'],
+        ['.used{color:red}', '<p class="us&#x65;d"></p>', '.used'],
+        ['#tgt{color:red}', '<p id="t&#103;t"></p>', '#tgt'],
+        ['.two{color:red}', '<p class="one&#32;two"></p>', '.two']
+      ];
+
+      for (const [css, markup, expected] of cases) {
+        const output = await minify(style(css) + markup, { minifyCSS: true, removeUnusedCSS: true });
+        assert.ok(styleOf(output).includes(expected), `${markup} should reference ${expected}`);
+      }
+
+      // A decoded value must not turn into a match for something else
+      const unrelated = await minify(style('.gone{color:red}') + '<p class="us&#101;d"></p>', {
+        minifyCSS: true,
+        removeUnusedCSS: true
+      });
+      assert.ok(!styleOf(unrelated).includes('.gone'), 'Unreferenced rules should still be removed');
+    });
+
+    test('Scans raw-text elements in linear time', () => {
+      // A regular expression permissive enough for malformed end tags backtracked
+      // quadratically here—30,000 near-matches took seconds rather than milliseconds
+      const input = '<style>' + '</style\t'.repeat(15000) + '<script>' + '<script\t'.repeat(15000);
+
+      const started = Date.now();
+      collectUsedSymbols(input, true);
+
+      assert.ok(Date.now() - started < 2000, 'Near-matches should not degrade into quadratic scanning');
     });
 
     test('Stops stripping a stylesheet at its own end tag, however malformed', async () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -874,6 +874,23 @@ describe('CSS and JS', () => {
       );
     });
 
+    test('Refuses a string value instead of reading it as “on”', async () => {
+      // A configuration file holding `"false"` would otherwise delete rules
+      const input = style('.unused{color:red}') + '<p></p>';
+      const logs = [];
+      const output = await minify(input, {
+        minifyCSS: true,
+        removeUnusedCSS: 'false',
+        log: message => logs.push(String(message))
+      });
+
+      assert.ok(styleOf(output).includes('.unused'), 'A string must not enable the option');
+      assert.ok(
+        logs.some(message => message.includes('removeUnusedCSS') && message.includes('string')),
+        'The rejected value should be reported'
+      );
+    });
+
     test('Reports that a `minifyCSS` function takes over', async () => {
       // The removal rides along with Lightning CSS, which a custom function replaces
       const input = style('.unused{color:red}') + '<p></p>';

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -804,6 +804,113 @@ describe('CSS and JS', () => {
     assert.ok(result.includes('function test(){}'), 'Empty function after console removal');
   });
 
+  test('Reports rules Lightning CSS skips under error recovery', async () => {
+    const input = '<style>@property --p{syntax:"<percentage>";inherits:false;initial-value:0}.a{color:red}</style>';
+    const logs = [];
+    const output = await minify(input, { minifyCSS: true, log: message => logs.push(String(message)) });
+
+    assert.ok(output.includes('.a{color:red}'), 'Valid rules should still be minified');
+    assert.ok(!output.includes('@property'), 'Invalid rule should be skipped, as browsers skip it');
+    assert.ok(
+      logs.some(message => message.startsWith('Warning: Lightning CSS skipped invalid CSS')),
+      'The skipped rule should be reported through `log`'
+    );
+  });
+
+  // Unused-CSS removal tests
+  describe('Unused CSS removal', () => {
+    const style = css => `<!doctype html><html><head><style>${css}</style></head><body>`;
+    const styleOf = html => (html.match(/<style>([\s\S]*?)<\/style>/) ?? ['', ''])[1];
+
+    test('Removes rules the document never references', async () => {
+      const input = style('.used{color:red}.unused{color:red}#gone{color:red}#kept{color:red}') +
+        '<p id="kept" class="used"></p>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.used'), 'Referenced class should be kept');
+      assert.ok(styleOf(output).includes('#kept'), 'Referenced ID should be kept');
+      assert.ok(!styleOf(output).includes('.unused'), 'Unreferenced class should be removed');
+      assert.ok(!styleOf(output).includes('#gone'), 'Unreferenced ID should be removed');
+    });
+
+    test('Requires `minifyCSS`', async () => {
+      const input = style('.unused{color:red}') + '<p></p>';
+      const output = await minify(input, { removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.unused'), 'Without `minifyCSS` nothing should be removed');
+    });
+
+    test('Keeps symbols referenced from ID references and `data-*` attributes', async () => {
+      const input = style('.late{color:red}#target{color:red}') +
+        '<button aria-controls="target" data-toggle-class="late"></button>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('#target'), '`aria-controls` should count as a reference');
+      assert.ok(styleOf(output).includes('.late'), '`data-*` values should count as references');
+    });
+
+    test('Keeps symbols named in inline scripts unless `scripts` is disabled', async () => {
+      const input = style('.js-only{color:red}') +
+        '<p></p><script>document.body.classList.add("js-only")</script>';
+
+      const guarded = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+      assert.ok(styleOf(guarded).includes('.js-only'), 'Inline script references should be kept by default');
+
+      const unguarded = await minify(input, { minifyCSS: true, removeUnusedCSS: { scripts: false } });
+      assert.ok(!styleOf(unguarded).includes('.js-only'), '`scripts: false` should drop the guard');
+    });
+
+    test('Honors the safelist, as strings and as regular expressions', async () => {
+      const input = style('.keep-me{color:red}.keep-prefix-a{color:red}.drop{color:red}') + '<p></p>';
+      const output = await minify(input, {
+        minifyCSS: true,
+        removeUnusedCSS: { safelist: ['keep-me', /^keep-prefix-/] }
+      });
+
+      assert.ok(styleOf(output).includes('.keep-me'), 'Safelisted string should be kept');
+      assert.ok(styleOf(output).includes('.keep-prefix-a'), 'Safelisted pattern should be kept');
+      assert.ok(!styleOf(output).includes('.drop'), 'Unsafelisted symbol should still be removed');
+    });
+
+    test('Never removes `@keyframes` or `@counter-style` a class name collides with', async () => {
+      const input = style('@keyframes spin{from{opacity:0}}.spin{animation:spin 1s}' +
+        '@counter-style tick{system:cyclic}.tick{list-style:tick}') + '<p></p>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('@keyframes spin'), '`@keyframes` must survive a colliding class name');
+      assert.ok(styleOf(output).includes('@counter-style tick'), '`@counter-style` must survive a colliding class name');
+    });
+
+    test('Leaves `style` and `media` attributes alone', async () => {
+      const input = '<p style="color:red" class="used"></p><link media="(min-width:0)" rel="stylesheet" href="a.css">';
+      const baseline = await minify(input, { minifyCSS: true });
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      // Attributes carry declarations and media queries, never selectors
+      assert.strictEqual(output, baseline);
+    });
+
+    test('Does not leak one document’s result into another through the CSS cache', async () => {
+      const sheet = '.alpha{color:red}.beta{color:red}';
+      const options = { minifyCSS: true, removeUnusedCSS: true };
+
+      const first = await minify(style(sheet) + '<p class="alpha"></p>', options);
+      const second = await minify(style(sheet) + '<p class="beta"></p>', options);
+
+      assert.ok(styleOf(first).includes('.alpha') && !styleOf(first).includes('.beta'));
+      assert.ok(styleOf(second).includes('.beta'), 'Second document must not inherit the first document’s output');
+      assert.ok(!styleOf(second).includes('.alpha'));
+    });
+
+    test('Resolves escaped identifiers when matching markup', async () => {
+      const input = style('.md\\:flex{display:flex}.lg\\:grid{display:grid}') + '<p class="md:flex"></p>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('flex'), 'Escaped class present in markup should be kept');
+      assert.ok(!styleOf(output).includes('grid'), 'Escaped class absent from markup should be removed');
+    });
+  });
+
   // Cache configuration tests
   describe('Caches', () => {
     test('Default sizes work', async () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -818,6 +818,30 @@ describe('CSS and JS', () => {
     );
   });
 
+  test('Reports a skipped CSS rule once, whatever the cache does', () => {
+    return (async () => {
+      const invalid = '@unknown-thing{foo:bar}';
+      const logs = [];
+      const options = {
+        minifyCSS: true,
+        cacheCSS: 1,
+        log: message => {
+          if (String(message).includes('skipped invalid CSS')) {
+            logs.push(String(message));
+          }
+        }
+      };
+
+      // Alternate two stylesheets through a one-entry cache, evicting on every pass
+      for (let pass = 0; pass < 6; pass++) {
+        const filler = pass % 2 ? '.a{color:red}' : '.b{color:blue}';
+        await minify(`<style>${invalid}${filler}</style><p class="a b"></p>`, options);
+      }
+
+      assert.strictEqual(logs.length, 1, 'The same invalid rule should be reported once, not once per cache miss');
+    })();
+  });
+
   // Unused-CSS removal tests
   describe('Unused CSS removal', () => {
     const style = css => `<!doctype html><html><head><style>${css}</style></head><body>`;
@@ -893,7 +917,11 @@ describe('CSS and JS', () => {
         ['.-foo{color:red}', '<script>document.body.classList.add("-foo")</script>', '.-foo'],
         ['.-mt-4{margin-top:-1rem}', '<script>el.classList.add("-mt-4")</script>', '.-mt-4'],
         ['.--foo{color:red}', '<script>el.classList.add("--foo")</script>', '.--foo'],
-        ['.-foo{color:red}', '<p data-toggle="-foo"></p>', '.-foo']
+        ['.-foo{color:red}', '<p data-toggle="-foo"></p>', '.-foo'],
+        // Two hyphens start an identifier whatever follows them
+        ['.--1foo{color:red}', '<script>el.classList.add("--1foo")</script>', '.--1foo'],
+        ['.---foo{color:red}', '<script>el.classList.add("---foo")</script>', '.---foo'],
+        ['.--1foo{color:red}', '<p data-toggle="--1foo"></p>', '.--1foo']
       ];
 
       for (const [css, markup, expected] of cases) {
@@ -901,12 +929,14 @@ describe('CSS and JS', () => {
         assert.ok(styleOf(output).includes(expected), `${markup} should keep ${expected}`);
       }
 
-      // A hyphen-leading name nothing references should still go
-      const unused = await minify(style('.-gone{color:red}') + '<p></p>', {
-        minifyCSS: true,
-        removeUnusedCSS: true
-      });
-      assert.ok(!styleOf(unused).includes('.-gone'), 'Unreferenced rules should still be removed');
+      // Hyphen-leading names nothing references should still go
+      for (const name of ['-gone', '--gone', '---gone']) {
+        const unused = await minify(style(`.${name}{color:red}`) + '<p></p>', {
+          minifyCSS: true,
+          removeUnusedCSS: true
+        });
+        assert.ok(!styleOf(unused).includes(`.${name}`), `Unreferenced .${name} should still be removed`);
+      }
     });
 
     test('Honors the safelist, as strings and as regular expressions', async () => {

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -1284,6 +1284,30 @@ describe('CSS and JS', () => {
       }
     });
 
+    test('Keeps what an `iframe srcdoc` document references', async () => {
+      // `srcdoc` holds a document of its own, and its style sheets are minified
+      // against the same symbol set, so its own classes have to be in it
+      const quote = String.fromCharCode(39);
+      const input = style('.outer{color:red}') + '<p class="outer"></p>' +
+        `<iframe srcdoc=${quote}<style>.inner{color:blue}.gone{color:red}</style><p class="inner">hi</p>${quote}></iframe>`;
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(output.includes('.inner'), 'A class the nested document uses should survive');
+      assert.ok(!output.includes('.gone'), 'A class nothing uses should still go');
+      assert.ok(output.includes('.outer'), 'The outer document should be unaffected');
+    });
+
+    test('Reads a start tag past a `>` inside a quoted attribute value', async () => {
+      // The tag ends where the parser says it does, so `id` is still an attribute
+      const output = await minify(
+        '<style media="(min-width:0)" title="a>b" id="theme">#theme{color:red}.gone{color:red}</style><p></p>',
+        { minifyCSS: true, removeUnusedCSS: true }
+      );
+
+      assert.ok(output.includes('#theme'), '`id` after a `>`-carrying value should still be read');
+      assert.ok(!output.includes('.gone'), 'Unreferenced rules should still be removed');
+    });
+
     test('Leaves a document without a style sheet exactly as `minifyCSS` alone would', async () => {
       const input = '<p class="a" data-x="b"></p><script>el.classList.add("c")</script>';
       const baseline = await minify(input, { minifyCSS: true });

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -805,7 +805,7 @@ describe('CSS and JS', () => {
     assert.ok(result.includes('function test(){}'), 'Empty function after console removal');
   });
 
-  test('Reports rules Lightning CSS skips under error recovery', async () => {
+  test('Reports invalid CSS Lightning CSS flags under error recovery', async () => {
     const input = '<style>@property --p{syntax:"<percentage>";inherits:false;initial-value:0}.a{color:red}</style>';
     const logs = [];
     const output = await minify(input, { minifyCSS: true, log: message => logs.push(String(message)) });
@@ -813,33 +813,85 @@ describe('CSS and JS', () => {
     assert.ok(output.includes('.a{color:red}'), 'Valid rules should still be minified');
     assert.ok(!output.includes('@property'), 'Invalid rule should be skipped, as browsers skip it');
     assert.ok(
-      logs.some(message => message.startsWith('Warning: Lightning CSS skipped invalid CSS')),
-      'The skipped rule should be reported through `log`'
+      logs.some(message => message.startsWith('Warning: Lightning CSS reported invalid CSS')),
+      'The rule should be reported through `log`'
     );
   });
 
-  test('Reports a skipped CSS rule once, whatever the cache does', () => {
-    return (async () => {
-      const invalid = '@unknown-thing{foo:bar}';
-      const logs = [];
-      const options = {
-        minifyCSS: true,
-        cacheCSS: 1,
-        log: message => {
-          if (String(message).includes('skipped invalid CSS')) {
-            logs.push(String(message));
-          }
-        }
-      };
+  test('Reports invalid CSS Lightning CSS keeps, without claiming it was dropped', async () => {
+    // Lightning CSS passes an unknown at-rule through and still warns, so the
+    // wording may not promise the rule is gone
+    const input = '<style>@unknown-thing{foo:bar}.a{color:red}</style>';
+    const logs = [];
+    const output = await minify(input, { minifyCSS: true, log: message => logs.push(String(message)) });
 
-      // Alternate two stylesheets through a one-entry cache, evicting on every pass
-      for (let pass = 0; pass < 6; pass++) {
-        const filler = pass % 2 ? '.a{color:red}' : '.b{color:blue}';
-        await minify(`<style>${invalid}${filler}</style><p class="a b"></p>`, options);
+    assert.ok(output.includes('@unknown-thing'), 'The rule is kept, so the report must not say it was skipped');
+    assert.ok(
+      logs.some(message => message.startsWith('Warning: Lightning CSS reported invalid CSS')),
+      'The rule should still be reported through `log`'
+    );
+    assert.ok(!logs.some(message => message.includes('skipped')), 'Nothing was skipped here');
+  });
+
+  test('Reports invalid CSS once per document, and for every document', async () => {
+    const invalid = '@unknown-thing{foo:bar}';
+    const collect = sink => message => {
+      if (String(message).includes('reported invalid CSS')) {
+        sink.push(String(message));
       }
+    };
 
-      assert.strictEqual(logs.length, 1, 'The same invalid rule should be reported once, not once per cache miss');
-    })();
+    // One defect across two style sheets: the document should hear about it once
+    const perDocument = [];
+    await minify(
+      `<style>${invalid}.a{color:red}</style><style>${invalid}.b{color:blue}</style><p class="a b"></p>`,
+      { minifyCSS: true, log: collect(perDocument) }
+    );
+    assert.strictEqual(perDocument.length, 1, 'One defect, one warning');
+
+    // The same document four times over, so every pass but the first is a cache
+    // hit: A hit must not swallow the warning for the document that hit it, or a
+    // batch would report the first file and pass the rest off as clean
+    const perBatch = [];
+    const options = { minifyCSS: true, log: collect(perBatch) };
+    for (let pass = 0; pass < 4; pass++) {
+      await minify(`<style>${invalid}.c{color:red}</style><p class="c"></p>`, options);
+    }
+    assert.strictEqual(perBatch.length, 4, 'Every document should hear about its own invalid rule');
+  });
+
+  describe('Object-valued options handed a string', () => {
+    // `'false'` used to switch minification on: Any non-empty string is truthy, and
+    // these options read a non-object as `{}`
+    const cases = [
+      ['minifyCSS', '<style>.a { color : red }</style>'],
+      ['minifyJS', '<script>var x  =  1</script>'],
+      ['minifySVG', '<svg><circle cx="1.00"/></svg>']
+    ];
+
+    for (const [key, input] of cases) {
+      test(`\`${key}\` refuses a string rather than reading it as “on”`, async () => {
+        const logs = [];
+        const output = await minify(input, { [key]: 'false', log: message => logs.push(String(message)) });
+
+        assert.strictEqual(output, input, `\`${key}: "false"\` must not enable minification`);
+        assert.ok(
+          logs.some(message => message.includes(key) && message.includes('string')),
+          `The rejected value should be reported (got ${JSON.stringify(logs)})`
+        );
+      });
+    }
+
+    test('`minifyURLs` still takes a string, which names the site', async () => {
+      // The one object-valued option where a string carries meaning, so it is
+      // deliberately left out of the check above
+      const input = '<a href="https://example.com/x/y.html">y</a>';
+
+      assert.strictEqual(
+        await minify(input, { minifyURLs: 'https://example.com/x/' }),
+        '<a href="y.html">y</a>'
+      );
+    });
   });
 
   // Unused-CSS removal tests
@@ -1096,16 +1148,22 @@ describe('CSS and JS', () => {
     test('Scans raw-text elements in linear time', () => {
       // A regular expression permissive enough for malformed end tags backtracked
       // quadratically over near-matches; compare growth rather than absolute time,
-      // which would depend on the machine. No `>` may follow the repetitions—one
-      // lets the pattern succeed immediately, which is what makes the near-matches
-      // pathological rather than merely long.
+      // which would depend on the machine, and keep the best of several runs, as a
+      // lone sample largely reports what else the machine was doing. No `>` may
+      // follow the repetitions—one lets the pattern succeed immediately, which is
+      // what makes the near-matches pathological rather than merely long.
       const measure = (/** @type {number} */ count) => {
         const input = '<style>' + '</style\t'.repeat(count);
-        const started = performance.now();
-        collectUsedSymbols(input, true);
-        return performance.now() - started;
+        let best = Infinity;
+        for (let run = 0; run < 3; run++) {
+          const started = performance.now();
+          collectUsedSymbols(input, true);
+          best = Math.min(best, performance.now() - started);
+        }
+        return best;
       };
 
+      measure(1000); // Warm up, so the first timed run is not the one that compiles
       const small = measure(8000);
       const large = measure(16000);
 
@@ -1137,6 +1195,100 @@ describe('CSS and JS', () => {
       for (const name of ['.js-a', '.js-b', '.js-c']) {
         assert.ok(styleOf(output).includes(name), `${name} should be safelisted`);
       }
+    });
+
+    test('Keeps IDs reached through a fragment URL', async () => {
+      // `:target` rules and SVG sprites name their element by fragment, never by
+      // an `id` attribute on the element doing the referencing
+      const cases = [
+        ['#sec:target{color:red}', '<a href="#sec">go</a>', '#sec'],
+        ['#ic{fill:red}', '<svg><use href="#ic"/></svg>', '#ic'],
+        ['#ic{fill:red}', '<svg><use xlink:href="#ic"/></svg>', '#ic'],
+        ['#m{color:red}', '<img usemap="#m">', '#m'],
+        // Presentation attributes reach a paint server the same way `style` does
+        ['#grad stop{stop-color:red}', '<svg><rect fill="url(#grad)"/></svg>', '#grad'],
+        ['#blur{flood-color:red}', '<p style="filter:url(#blur)"></p>', '#blur']
+      ];
+
+      for (const [css, markup, expected] of cases) {
+        const output = await minify(style(css) + markup, { minifyCSS: true, removeUnusedCSS: true });
+        assert.ok(styleOf(output).includes(expected), `${markup} should keep ${expected}`);
+      }
+
+      // A fragment on another document names nothing here, so it protects nothing
+      const external = await minify(style('#gone{color:red}') + '<a href="/page#gone">x</a>', {
+        minifyCSS: true,
+        removeUnusedCSS: true
+      });
+      assert.ok(!styleOf(external).includes('#gone'), 'A fragment on another document is not a local reference');
+    });
+
+    test('Keeps class names whose characters end a CSS identifier', async () => {
+      // `md:flex`, `w-1/2`, and `p-[3px]` are ordinary class names in utility CSS;
+      // an identifier scan stops at the `:`, `/`, or `[` and would lose them
+      const cases = [
+        ['.md\\:flex{display:flex}', '<script>el.classList.add("md:flex")</script>', 'flex'],
+        ['.w-1\\/2{width:50%}', '<script>el.classList.add(\'w-1/2\')</script>', 'width'],
+        ['.p-\\[3px\\]{padding:3px}', '<script>el.classList.add("p-[3px]")</script>', 'padding'],
+        ['.tpl\\:x{color:red}', '<script>el.className=`tpl:x`</script>', 'color'],
+        // A name may not start with a digit unescaped, but it may be one
+        ['.\\31 col{width:1px}', '<script>el.classList.add("1col")</script>', 'width'],
+        ['.md\\:flex{display:flex}', '<p data-c="md:flex"></p>', 'flex']
+      ];
+
+      for (const [css, markup, expected] of cases) {
+        const output = await minify(style(css) + '<p></p>' + markup, { minifyCSS: true, removeUnusedCSS: true });
+        assert.ok(styleOf(output).includes(expected), `${markup} should keep ${css}`);
+      }
+
+      // Nothing references these, so the widened scan must not keep them either
+      const unused = await minify(style('.md\\:gone{display:flex}.q-\\[1px\\]{padding:1px}') + '<p></p>', {
+        minifyCSS: true,
+        removeUnusedCSS: true
+      });
+      assert.strictEqual(styleOf(unused), '', 'Unreferenced names should still be removed');
+    });
+
+    test('Reads a style sheet’s own attributes, not its contents', async () => {
+      const output = await minify(
+        '<style id="theme" class="t">#theme{color:red}.t{color:red}.gone{color:red}</style><p></p>',
+        { minifyCSS: true, removeUnusedCSS: true }
+      );
+
+      assert.ok(output.includes('#theme'), '`<style id="theme">` is what `#theme` refers to');
+      assert.ok(output.includes('.t'), 'A class on the element itself counts too');
+      assert.ok(!output.includes('.gone'), 'The sheet is still no evidence for its own selectors');
+    });
+
+    test('Reports values it has to ignore rather than silently protecting nothing', async () => {
+      // Each case uses a distinct message: `processOptions` reports a given warning
+      // once per process, as it does for unknown option keys
+      const cases = [
+        [{ safelist: 'js-' }, 'safelist'],
+        [{ safelist: [42] }, 'type number'],
+        [{ scripts: 'false' }, 'scripts'],
+        [{ safeList: ['x'] }, 'safeList']
+      ];
+
+      for (const [config, expected] of cases) {
+        const logs = [];
+        await minify(style('.drop{color:red}') + '<p></p>', {
+          minifyCSS: true,
+          removeUnusedCSS: config,
+          log: message => logs.push(String(message))
+        });
+        assert.ok(
+          logs.some(message => message.includes(expected)),
+          `${JSON.stringify(config)} should be reported (got ${JSON.stringify(logs)})`
+        );
+      }
+    });
+
+    test('Leaves a document without a style sheet exactly as `minifyCSS` alone would', async () => {
+      const input = '<p class="a" data-x="b"></p><script>el.classList.add("c")</script>';
+      const baseline = await minify(input, { minifyCSS: true });
+
+      assert.strictEqual(await minify(input, { minifyCSS: true, removeUnusedCSS: true }), baseline);
     });
   });
 

--- a/test/css+js.test.js
+++ b/test/css+js.test.js
@@ -909,6 +909,45 @@ describe('CSS and JS', () => {
       assert.ok(styleOf(output).includes('flex'), 'Escaped class present in markup should be kept');
       assert.ok(!styleOf(output).includes('grid'), 'Escaped class absent from markup should be removed');
     });
+
+    test('Survives out-of-range escapes instead of throwing', async () => {
+      // `\FFFFFF` exceeds the maximum code point; per CSS Syntax it resolves to U+FFFD
+      const input = style(String.raw`.\FFFFFF{color:red}.b{color:red}`) + '<p class="b"></p>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.b'), 'Referenced class should survive an out-of-range escape');
+    });
+
+    test('Still applies when a custom fragment is present', async () => {
+      // `<%…%>` is matched by the default `ignoreCustomFragments`, which swaps in a
+      // wrapper around `minifyCSS` that must keep forwarding the symbol set
+      const input = style('.used{color:red}.unused{color:red}') + '<p class="used"></p><%= tpl %>';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.used'), 'Referenced class should be kept');
+      assert.ok(!styleOf(output).includes('.unused'), 'Custom fragments must not disable the option');
+    });
+
+    test('Reads raw-text elements whose end tag carries whitespace', async () => {
+      const input = style('.js-x{color:red}') +
+        '<p></p><script>document.body.classList.add("js-x")</script >';
+      const output = await minify(input, { minifyCSS: true, removeUnusedCSS: true });
+
+      assert.ok(styleOf(output).includes('.js-x'), '`</script >` should still be recognized as an end tag');
+    });
+
+    test('Honors a safelist entry that is a global regular expression', async () => {
+      const input = style('.js-a{color:red}.js-b{color:red}.js-c{color:red}') + '<p></p>';
+      const output = await minify(input, {
+        minifyCSS: true,
+        removeUnusedCSS: { safelist: [/^js-/g] }
+      });
+
+      // A stateful pattern would otherwise match only every other symbol
+      for (const name of ['.js-a', '.js-b', '.js-c']) {
+        assert.ok(styleOf(output).includes(name), `${name} should be safelisted`);
+      }
+    });
   });
 
   // Cache configuration tests

--- a/test/fixtures/invalid-css-js.html
+++ b/test/fixtures/invalid-css-js.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Invalid CSS and JavaScript</title>
+		<style>.valid{color:red}.broken{{{</style>
+		<script>function valid(){return 1} this is not valid js</script>
+	</head>
+	<body>
+		<p class="valid">Test</p>
+	</body>
+</html>

--- a/test/fixtures/unused-css.html
+++ b/test/fixtures/unused-css.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Unused CSS</title>
+		<style>.used{color:red}.unused{color:red}.safe-a{color:red}</style>
+	</head>
+	<body>
+		<p class="used">Test</p>
+	</body>
+</html>

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -2500,7 +2500,7 @@ describe('HTML', () => {
 
     input = '<img class="{% foo %} {% bar %}">';
     assert.strictEqual(await minify(input, { ignoreCustomFragments: [/\{%[^%]*?%\}/g] }), input);
-    // `trimCustomFragments` without `collapseWhitespace`, does not break the “{% foo %} {% bar %}” test
+    // `trimCustomFragments` without `collapseWhitespace`, does not break the `{% foo %} {% bar %}` test
     assert.strictEqual(await minify(input, { ignoreCustomFragments: [/\{%[^%]*?%\}/g], trimCustomFragments: true }), input);
     // `trimCustomFragments` with `collapseWhitespace`, changes output
     output = '<img class="{% foo %}{% bar %}">';

--- a/test/json-schema.test.js
+++ b/test/json-schema.test.js
@@ -15,19 +15,19 @@ describe('JSON Schema', () => {
 
   test('Schema covers every option definition', () => {
     for (const key of Object.keys(optionDefinitions)) {
-      assert.ok(key in schemaOnDisk.properties, `Missing schema property for option “${key}”`);
+      assert.ok(key in schemaOnDisk.properties, `Missing schema property for option \`${key}\``);
     }
   });
 
   test('Every schema property has a type or enum (catches option types missing from the generator)', () => {
     for (const [key, property] of Object.entries(schemaOnDisk.properties)) {
-      assert.ok(property.type || property.enum, `Missing type mapping for schema property “${key}”`);
+      assert.ok(property.type || property.enum, `Missing type mapping for schema property \`${key}\``);
     }
   });
 
   test('Every schema property has a description', () => {
     for (const [key, property] of Object.entries(schemaOnDisk.properties)) {
-      assert.ok(typeof property.description === 'string' && property.description.length, `Missing description for schema property “${key}”`);
+      assert.ok(typeof property.description === 'string' && property.description.length, `Missing description for schema property \`${key}\``);
     }
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional unused CSS removal with safelisting and inline-script scanning support.
  * Added minifier diagnostics for verbose and dry-run CLI modes.
  * Added demo and configuration schema support for the new option.
* **Bug Fixes**
  * Improved reporting of skipped CSS rules and JavaScript minification errors while preserving successful output.
  * Standardized diagnostic and help-text quotation formatting.
  * Added validation to reject invalid string values for object-based minification options.
* **Documentation**
  * Updated CLI and CSS minification guidance, including error-recovery reporting and unused CSS handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->